### PR TITLE
Recreate changes for EUDAT-443

### DIFF
--- a/simplestore/etc/static/css/simplestore-style.css
+++ b/simplestore/etc/static/css/simplestore-style.css
@@ -266,6 +266,10 @@ textarea {
     height: 100px;
 }
 
+.switch {
+    width: 280px;
+    margin-left: 0px;
+}
 
 a.description {
     position: relative;

--- a/simplestore/etc/templates/simplestore-addmeta-table.html
+++ b/simplestore/etc/templates/simplestore-addmeta-table.html
@@ -1,15 +1,21 @@
-
 {# would have been easier if wtf bs let me pass in css classes to horizontal_field #}
 {{ form.csrf_token }}
 {% macro meta_field(f) %}
+<tr>
 <div class="compact-form {% if f.errors %}error{% endif %}">
-  {{f.label(class="control-label meta-label")}} {%- if f.flags.required -%}<span style="color: red;">&nbsp;*</span>{%else%}<span>&nbsp;&nbsp;</span>{%- endif %}
-    {{f(**kwargs)|safe}}
 
-  {%- if f.description -%}
-    <a class="description" href="#"><button type="button" class="btn btn-mini btn-info disabled">
-    <i class="icon-info-sign"></i></button><span>{{f.description|safe}}</span></a>
-  {%- endif %}
+
+<td>
+  {{f.label(class="control-label meta-label")}}
+</td>
+
+<td>
+  {%- if f.flags.required -%}
+    <span style="color: red;">&nbsp;*</span>{%else%}<span>&nbsp;&nbsp;</span>{%- endif %}
+</td>
+<td>
+    <div title="{{f.description}}" rel='tooltip' placement='right' container='body'> {{f(**kwargs)|safe}}</div>
+</td>
   
   <div class="controls">
 
@@ -18,15 +24,17 @@
         <p class="help-block">{{error}}</p>
       {%- endfor %}
     {%- endif %}
-  
+
   </div>
 </div>
+</tr>
 {% endmacro %}
 
 {% for s in metadata.fieldsets %}
   <fieldset>
     <legend>{{ s.name }}</legend>
 
+<table>
     {% for f in s.basic_fields %}
       {{ meta_field(getattr(form, f)) }}
     {% endfor %}
@@ -35,15 +43,15 @@
       <button type="button" class="btn btn-success" data-toggle="collapse" data-target="#adv-fields-{{ s.name }}">
                     Add more details?
       </button>
- 
-      <div id="adv-fields-{{ s.name }}" class="collapse"> 
-
+</table>
+      <div id="adv-fields-{{ s.name }}" class="collapse">
+<table>
         {% for f in s.optional_fields %}
           {{ meta_field(getattr(form, f)) }}
         {% endfor %}
       </div>
     {% endif %}
-
+</table>
   </fieldset>
 {% endfor %}
 <script type="text/javascript">
@@ -57,5 +65,14 @@
       defaultDate: new Date()
     });
 </script>
+
+<script type="text/javascript">
+   $(document).ready(function() {
+   $("[rel='tooltip']").tooltip(
+       trigger: 'hover',
+       delay: 5000,
+       placement: 'left'
+   });
+})
 
 </script>


### PR DESCRIPTION
- Align "Open Access" switch
- Remove blue 'i' buttons - replace with hover
- Layout survives text size change
