### PR TITLE
Fixes issue 169. (https added to file url)

### DIFF
--- a/invenio/templates/record.html
+++ b/invenio/templates/record.html
@@ -66,10 +66,10 @@
             <tbody>
               {%- for file in files -%}
                 <tr class="">
-                  <td><a href="{{file.get_url()}}">{{ file.get_full_name() }}</a></td>
+                  <td><a href="https://{{file.get_url()}}">{{ file.get_full_name() }}</a></td>
                   <td>{{ file.md.strftime('%d %b %Y') }}</td>
                   <td>{{ file.size|filesizeformat }}</td>
-                  <td><span class="pull-right">{% if file.get_superformat() == '.pdf' %}<button class="btn preview-link" data-url="{{file.get_url()}}"><i class="icon-eye-open"></i> {{_("Preview")}}</button>{% endif %} <a class="btn" href="{{file.get_url()}}"><i class="icon-download"></i> {{_("Download")}}</a></span></td>
+                  <td><span class="pull-right">{% if file.get_superformat() == '.pdf' %}<button class="btn preview-link" data-url="https://{{file.get_url()}}"><i class="icon-eye-open"></i> {{_("Preview")}}</button>{% endif %} <a class="btn" href="{{file.get_url()}}"><i class="icon-download"></i> {{_("Download")}}</a></span></td>
                 </tr>
               {%- endfor -%}
             </tbody>


### PR DESCRIPTION
It turned out that when a user was not logged in, the problem with displaying files with names containing wierd characters didn't exist. The only problem was that a logged-in user tried to display a non-secured page. 
(don't know why it only occured with files with wierd characters in their names, though; with "normal" files https is added automatically)
