### PR TITLE
fixed #203: Download button now downloads

### DIFF
--- a/invenio/lib/bibdocfile.py
+++ b/invenio/lib/bibdocfile.py
@@ -2972,9 +2972,10 @@ class BibDocFile(object):
     def get_url(self):
         return self.url
 
-    def get_full_url(self):
-        """Returns absolute url."""
-        return self.fullurl
+    def get_full_url(self, download=False):
+        """Returns the absolute file url, with optional forced download."""
+        # self.fullurl always has at least one attribute
+        return "%s%s" % (self.fullurl, download and "&download=1" or "")
 
     def get_type(self):
         """Returns the first type connected with the bibdoc of this file."""

--- a/invenio/templates/record.html
+++ b/invenio/templates/record.html
@@ -69,7 +69,7 @@
                   <td><a href="{{file.get_url()}}">{{ file.get_full_name() }}</a></td>
                   <td>{{ file.md.strftime('%d %b %Y') }}</td>
                   <td>{{ file.size|filesizeformat }}</td>
-                  <td><span class="pull-right">{% if file.get_superformat() == '.pdf' %}<button class="btn preview-link" data-url="{{file.get_full_url()}}"><i class="icon-eye-open"></i> {{_("Preview")}}</button>{% endif %} <a class="btn" href="{{file.get_full_url()}}"><i class="icon-download"></i> {{_("Download")}}</a></span></td>
+                  <td><span class="pull-right">{% if file.get_superformat() == '.pdf' %}<button class="btn preview-link" data-url="{{file.get_full_url()}}"><i class="icon-eye-open"></i> {{_("Preview")}}</button>{% endif %} <a class="btn" href="{{file.get_full_url(download=True)}}"><i class="icon-download"></i> {{_("Download")}}</a></span></td>
                 </tr>
               {%- endfor -%}
             </tbody>


### PR DESCRIPTION
It took me a while to track the file downloading code: it's in bibdocfile_webinterface.py, class WebInterfaceFilesPages (it uses the legacy routing mechanism). The exact function that does the file streaming is at line 223 (return docfile.stream). From that file we can see that just adding the right parameter to the URL we get forced file downloads (download=1).
