### PR TITLE
Fix typeahead.js version deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ckeditor": "latest"
   },
   "devDependencies": {
-    "typeahead.js": "0.10.1",
+    "typeahead.js": "0.10.4",
     "hogan": "3.0.0",
     "jquery-tokeninput": "*",
     "MathJax": "v2.1-latest",


### PR DESCRIPTION
Updated `typeahead.js` to newer version conflict with `typeahead.js-bootstrap3.less`. Tested and build from invenio-scripts.

This pull-request fixes: https://github.com/EUDAT-B2SHARE/b2share/issues/347
