### PR TITLE
Static document pages with travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
   - "sudo mkdir /etc/apache2/ssl"
   - "sudo /usr/sbin/make-ssl-cert /usr/share/ssl-cert/ssleay.cnf /etc/apache2/ssl/apache.pem"
   - "travis_retry pip install . --process-dependency-links --allow-all-external --quiet"
+  - "travis_retry pip install -r requirements-b2share.txt --allow-all-external --quiet"
   - "travis_retry pip install -r requirements-mongo.txt --allow-all-external --quiet"
   - "travis_retry pip install -r requirements-img.txt --quiet"
   - "travis_retry pip install -r requirements-extras.txt --quiet"


### PR DESCRIPTION
Reapply https://github.com/EUDAT-B2SHARE/b2share/pull/352 with a fix for Travis.
Added a structure for displaying markdown (wiki) documentation as described in ticket: #326
NOTE: a new dependency: markdown is added to `requirements-b2share.txt`

Travis did not build requirements for b2share, wait for the green Travis-CI build before merging.
