### PR TITLE
Remove Travis python26 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ services:
 language: python
 
 python:
-  - "2.6"
   - "2.7"
 
 install:


### PR DESCRIPTION
Removing python26 build in Travis-CI because it fails builds since: https://github.com/EUDAT-B2SHARE/b2share/pull/382. Not sure if the pull-request caused the issue, it can be an issue with Travis-CI for that specific version. 
