### PR TITLE
fixed #450: typeahead now working in deposit page

### DIFF
--- a/invenio/b2share/modules/b2deposit/templates/b2share-addmeta-table.html
+++ b/invenio/b2share/modules/b2deposit/templates/b2share-addmeta-table.html
@@ -148,3 +148,35 @@
     $('.multiselect').multiselect();
   });
 </script>
+
+<script type="text/javascript">
+  // setup typeahead
+  $(document).ready(function() {
+    var substringMatcher = function(strs) {
+        return function findMatches(q, cb) {
+            var matches = [];
+            var substrRegex = new RegExp(q, 'i');
+            $.each(strs, function(i, str) {
+                if (substrRegex.test(str)) {
+                    matches.push({ value: str });
+                }
+            });
+            cb(matches);
+        };
+    };
+
+    $("#meta input[data-provide='typeahead']").each(function() {
+        var qthis = $(this);
+        var dataset = JSON.parse(qthis.attr('data-source'));
+        console.log("typeahead: ", this, dataset);
+        qthis.typeahead('destroy');
+        qthis.typeahead({
+            hint: true,
+            highlight: true,
+            minLength: 1
+        }, {
+            source: substringMatcher(dataset)
+        });
+    });
+  });
+</script>

--- a/invenio/b2share/modules/b2deposit/templates/b2share-deposit.html
+++ b/invenio/b2share/modules/b2deposit/templates/b2share-deposit.html
@@ -8,6 +8,7 @@
     {% css 'css/bootstrap-switch.css', '50-b2share' %}
     {% css 'css/bootstrap-multiselect.css', '50-b2share' %}
     {% css 'css/jquery-ui.css', '50-b2share' %}
+    {% css 'css/typeahead.js-bootstrap.css' %}
 {%- endblock global_css -%}
 
 {%- block global_javascript -%}
@@ -17,6 +18,7 @@
     {%- js 'js/bootstrap-multiselect.js', '50-b2share' -%}
     {%- js 'js/jquery-ui-1.10.3.custom.min.js', '50-b2share' -%}
     {%- js 'js/b2share-deposit.js', '50-b2share' -%}
+    {%- js "js/typeahead.js" -%}
 {%- endblock global_javascript -%}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
Fixes #450. Can be verified by filling in the License field in the depositing page (pressing 'a' should trigger the typeahead menu).
