### PR TITLE
Master#273 fix resource type

### DIFF
--- a/invenio/b2share/modules/b2deposit/b2share_marc_handler.py
+++ b/invenio/b2share/modules/b2deposit/b2share_marc_handler.py
@@ -90,7 +90,13 @@ def add_basic_fields(rec, form, email):
         if form.get('resource_type'):
             fields = form.getlist('resource_type')
             for f in fields:
-                record_add_field(rec, '980', subfields=[('a', remove_html_markup(form['resource_type']))])
+                record_add_field(rec, '980', subfields=[('a', remove_html_markup(f))])
+        # special case for the Linguistics domain:
+        # all the ling_resource_type(s) are also resource_type(s), going in field 980
+        if form.get('ling_resource_type'):
+            fields = form.getlist('ling_resource_type')
+            for f in fields:
+                record_add_field(rec, '980', subfields=[('a', remove_html_markup(f))])
 
         if form.get('alternate_identifier'):
             record_add_field(rec, '024',

--- a/invenio/b2share/modules/b2deposit/b2share_model/metadata/linguistics_metadata_config.py
+++ b/invenio/b2share/modules/b2deposit/b2share_model/metadata/linguistics_metadata_config.py
@@ -31,6 +31,9 @@ fields = [
         'display_text': 'Resource Type',
         'col_type': db.String(256),
         'required': True,
+        'data_provide': 'select',
+        'cardinality': 'n',
+        'data_source': ['Text', 'Image', 'Video', 'Audio', 'Time-Series', 'Other'],
         'description': 'This element allows the depositor to specify the type '
                        'of the resource (Text, Audio, Video, Time-Series, Photo, etc.)'
     },

--- a/invenio/b2share/modules/b2deposit/b2share_model/model.py
+++ b/invenio/b2share/modules/b2deposit/b2share_model/model.py
@@ -148,7 +148,7 @@ class SubmissionMetadata(db.Model):
         self.field_args['resource_type'] = {
             'data_provide': 'select',
             'cardinality': 'n',
-            'data_source': ['Text', 'Image', 'Video', 'Other'],
+            'data_source': ['Text', 'Image', 'Video', 'Audio', 'Time-Series', 'Other'],
             'description': 'Select the type of the resource.'
         }
         self.field_args['alternate_identifier'] = {

--- a/invenio/b2share/modules/b2deposit/static/css/b2share-style.css
+++ b/invenio/b2share/modules/b2deposit/static/css/b2share-style.css
@@ -278,7 +278,7 @@ img.desaturate {
     display: none;
 }
 
-input, textarea {
+input[type='text'], textarea {
     width: 270px;
 }
 textarea {

--- a/invenio/b2share/modules/b2deposit/templates/b2share-addmeta-table.html
+++ b/invenio/b2share/modules/b2deposit/templates/b2share-addmeta-table.html
@@ -151,9 +151,10 @@
   });
 </script>
 
+{# setup typeahead #}
 <script type="text/javascript">
-  // setup typeahead
   $(document).ready(function() {
+    'use strict';
     var substringMatcher = function(strs) {
         return function findMatches(q, cb) {
             var matches = [];
@@ -182,6 +183,7 @@
   });
 </script>
 
+{# dynamically add license selector button #}
 <script type="text/javascript">
   $(document).ready(function() {
     'use strict';
@@ -195,3 +197,13 @@
     });
   });
 </script>
+
+{# if Linguistics domain, remove the duplicated resource_type input #}
+{% if metadata.domain.lower() == 'linguistics' -%}
+<script type="text/javascript">
+  $(document).ready(function() {
+    'use strict';
+    $('#resource_type').closest('tr').remove();
+  });
+</script>
+{%- endif %}


### PR DESCRIPTION
Fixed #273: when the user picks the Linguistics domain, the optional resource_type basic field is hidden and the content of the required, domain-specific, ling_resource_type field is used instead