### PR TITLE
Use the Unity userinfo endpoint to get user information; fix flask-oauth

### DIFF
--- a/invenio/base/config.py
+++ b/invenio/base/config.py
@@ -86,14 +86,10 @@ OAUTHCLIENT_REMOTE_APPS = dict(
 )
 
 UNITY_APP_CREDENTIALS = dict(
-    consumer_key= "d9b4b207-1e4c-491c-a06e-448eb8f4d958",
-    consumer_secret= "f562e168-8b1b-4004-a074-29ba8852a4d5",
+    # will only work on development configurations
+    consumer_key= "b2share",
+    consumer_secret= "b2share8juelich",
 )
-
-# GITHUB_APP_CREDENTIALS = dict(
-#     consumer_key="3f2a2a514db4a9cbeca7",
-#     consumer_secret="d56092786135595a778104d471ba4ab0b5dd61a6",
-# )
 
 CFG_PREFIX = distutils.sysconfig.get_config_var("prefix")
 

--- a/invenio/modules/oauthclient/views/client.py
+++ b/invenio/modules/oauthclient/views/client.py
@@ -121,6 +121,8 @@ def setup_app():
                 view=account_view_handler,
             )
         )
+        if conf.get('setup'):
+                conf.get('setup')(remote)
 
 
 @blueprint.route('/login/<remote_app>/')


### PR DESCRIPTION
Now the user info is correctly retrieved from Unity after the Unity authentication, and the user gets a username and an email. 

This PR also hacks the current flask-oauthlib implementation to send the HTTP Auth header as expected by the Unity auth server. About this, see also https://github.com/lepture/flask-oauthlib/issues/199