### PR TITLE
global: fix global indexing in install script

### DIFF
--- a/install/install_b2share.sh
+++ b/install/install_b2share.sh
@@ -123,6 +123,8 @@ mysql -u root --database=invenio --password=$MYSQL_ROOT -e "$GRANT"
 
 echo; echo "### Setup bibtasks: bibindex"
 bibindex -f50000 -s5m -uadmin
+# another bibindex scheduling for global index because it is a virtual index
+bibindex -w global -f50000 -s5m -uadmin
 
 echo; echo "### Setup bibtasks: bibreformat"
 bibreformat -oHB -s5m -uadmin


### PR DESCRIPTION
* FIX Schedule a new bibindex for global index as described here
  b2share/invenio/legacy/webhelp/doc/admin/howto/howto-run.webdoc
  (closes #652). Whithout this the global index was not updated.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>