### PR TITLE
b2deposit: Improve checksum tests

### DIFF
--- a/invenio/b2share/modules/b2deposit/restful.py
+++ b/invenio/b2share/modules/b2deposit/restful.py
@@ -482,13 +482,23 @@ class DepositionCommit(B2Resource):
 
 
 def setup_app(app, api):
-    api.add_resource(ApiRoot, '/api/')
+    api.add_resource(ApiRoot, '/api/',
+                     endpoint='b2deposit.apiroot')
 
-    api.add_resource(ListRecords, '/api/records/')
-    api.add_resource(ListRecordsByDomain, '/api/records/<string:domain_name>')
-    api.add_resource(RecordRes, '/api/record/<int:record_id>')
+    api.add_resource(ListRecords, '/api/records/',
+                     endpoint='b2deposit.listrecords')
+    api.add_resource(ListRecordsByDomain, '/api/records/<string:domain_name>',
+                     endpoint='b2deposit.listrecordsbydomain')
+    api.add_resource(RecordRes, '/api/record/<int:record_id>',
+                     endpoint='b2deposit.recordres')
 
-    api.add_resource(ListDepositions, '/api/depositions/')
-    api.add_resource(Deposition, '/api/deposition/<string:deposit_id>')
-    api.add_resource(DepositionFiles, '/api/deposition/<string:deposit_id>/files')
-    api.add_resource(DepositionCommit, '/api/deposition/<string:deposit_id>/commit')
+    api.add_resource(ListDepositions, '/api/depositions/',
+                     endpoint='b2deposit.listdepositions')
+    api.add_resource(Deposition, '/api/deposition/<string:deposit_id>',
+                     endpoint='b2deposit.deposition')
+    api.add_resource(DepositionFiles,
+                     '/api/deposition/<string:deposit_id>/files',
+                     endpoint='b2deposit.depositionfiles')
+    api.add_resource(DepositionCommit,
+                     '/api/deposition/<string:deposit_id>/commit',
+                     endpoint='b2deposit.depositioncommit')

--- a/invenio/b2share/testsuite/test_checksums.py
+++ b/invenio/b2share/testsuite/test_checksums.py
@@ -2,48 +2,58 @@
 """Tests for checksumming b2share deposits"""
 
 from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+
 import os, os.path, time, hashlib
-from .helpers import InitHelper, TmpHelper, RestApi
 
+from .helpers import B2ShareAPITestCase, TmpHelper
 
-class TestB2ShareChecksums(InvenioTestCase):
+from flask import current_app
+
+class TestB2ShareChecksums(B2ShareAPITestCase):
     """Unit tests for stability of checksums, using the REST API"""
 
     def setUp(self):
-        InitHelper.init_user_token(self)
+        self.create_and_login_user()
 
     def tearDown(self):
+        self.remove_user()
         TmpHelper.delete_all_tmp_files()
 
-    def create_record(self, api, metadata, files):
+    def create_record(self, metadata, files):
+        """create a deposition, add some files and commit the record."""
+        current_app.config.update(PRESERVE_CONTEXT_ON_EXCEPTION= False)
         # create deposition object
-        request_create = api.create_deposition()
+        request_create = self.create_deposition()
+        print repr(request_create)
         self.assertTrue(request_create.status_code == 201)
-        location = request_create.json()['location']
+        location = request_create.json['location']
+        # FIXME: the api should return the deposition id. We should not have to
+        # parse the uri
+        deposit_id = location.split('/')[3]
 
         # upload files
         for f in files:
-            postfile = (os.path.basename(f), open(f, 'rb'), 'text/plain')
-            request_upload = api.upload_deposition_file(location, postfile)
+            request_upload = self.upload_deposition_file(
+                deposit_id=deposit_id,
+                file_stream=open(f,'rb'),
+                file_name=os.path.basename(f)
+            )
             self.assertTrue(request_upload.status_code == 200)
 
         # commit deposition
-        request_commit = api.commit_deposition(location, metadata)
+        request_commit = self.commit_deposition(deposit_id, metadata)
         self.assertTrue(request_commit.status_code == 201)
-        location = request_commit.json()['location']
+        location = request_commit.json['location']
+        # FIXME: the api should return the record id. We should not have to
+        # parse the uri
+        record_id = location.split('/')[3]
 
-        # get record (via location) and wait for it to be made
-        request_get = None
-        for i in range(0, 10):
-            time.sleep(5)
-            request_get = api.get_by_uri(location)
-            if request_get.status_code == 200:
-                break
-            self.assertEquals(request_get.status_code, 404)
-        else:
+        # get record
+        request_get = self.get_record(record_id)
+        if request_get.status_code != 200:
             self.fail('timeout while in the rest deposition')
 
-        deposit_json = request_get.json()['Deposit']
+        deposit_json = request_get.json['Deposit']
         posted_files = set([os.path.basename(f) for f in files])
         deposited_files = set([f['name'] for f in deposit_json['files']])
         self.assertEquals(posted_files, deposited_files)
@@ -62,8 +72,6 @@ class TestB2ShareChecksums(InvenioTestCase):
         return sha.hexdigest()
 
     def test_deposit_checksums(self):
-        api = RestApi(url=self.current_app_url, access_token=self.access_token)
-
         metadata1 = {
             'domain': "generic",
             'title': 'Checksum test',
@@ -82,14 +90,14 @@ class TestB2ShareChecksums(InvenioTestCase):
         computed_checksum = self.compute_checksum(files1)
         self.assertEquals(checksum, computed_checksum)
 
-        rec = self.create_record(api, metadata1, files1)
+        rec = self.create_record(metadata1, files1)
         self.assertEquals(checksum, rec['checksum'])
 
-        rec_identical = self.create_record(api, metadata1, files1)
+        rec_identical = self.create_record(metadata1, files1)
         self.assertEquals(checksum, rec_identical['checksum'])
 
         reversed_files = list(reversed(files1))
-        rec_reversed = self.create_record(api, metadata1, reversed_files)
+        rec_reversed = self.create_record(metadata1, reversed_files)
         self.assertEquals(checksum, rec_reversed['checksum'])
 
         metadata2 = {
@@ -101,14 +109,14 @@ class TestB2ShareChecksums(InvenioTestCase):
             'ling_resource_type': ['Text']
         }
 
-        rec_diffmeta = self.create_record(api, metadata2, files1)
+        rec_diffmeta = self.create_record(metadata2, files1)
         self.assertEquals(checksum, rec_diffmeta['checksum'])
 
         files2 = []
         files2.extend(files1)
         files2.append(TmpHelper.create_tmp_file("testfile3.txt", "yet another test file"))
 
-        rec_diff = self.create_record(api, metadata1, files2)
+        rec_diff = self.create_record(metadata1, files2)
         self.assertNotEquals(checksum, rec_diff['checksum'])
 
 

--- a/invenio/b2share/testsuite/test_helpers.py
+++ b/invenio/b2share/testsuite/test_helpers.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# This file is part of B2SHARE.
+# Copyright (C) 2015 CERN.
+#
+# B2SHARE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# B2SHARE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with B2SHARE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""Tests of the test helpers"""
+
+import unittest
+
+from .helpers import TemporaryDirectory
+
+
+class TestTemporaryDirectory(unittest.TestCase):
+    """Test TemporaryDirectory context manager"""
+
+    def test_temporary_directory(self):
+        """Test dir creation and deletion"""
+        import os.path
+        dir_path = None
+        file_path = None
+        with TemporaryDirectory() as tmp_dir:
+            dir_path = tmp_dir
+            file_path = os.path.join(tmp_dir, "testfile.txt")
+            # test that the directory exists
+            self.assertTrue(os.path.isdir(dir_path))
+            # test that we can create files in it
+            with open(file_path, 'w') as file_desc:
+                file_desc.write("mycontent")
+            self.assertTrue(os.path.isfile(file_path))
+        # check that the directory and file have been deleted
+        self.assertFalse(os.path.isfile(file_path))
+        self.assertFalse(os.path.isdir(dir_path))


### PR DESCRIPTION
- declares REST API endpoints so that they can be used in tests.
- fixes tests (there where some syntax errors).
- uses `invenio.ext.restful.util.APITestCase` and refactor `RestAPI` as `B2ShareAPITestCase `.
- adds and use a basic implementation of `tempfile.TemporaryDirectory`. This avoids the creation of temporary directories in the source directory.
- runs bibupload tasks without depending on bibsched.

(closes: #660)