### PR TITLE
Fixed admin page (double inclusion of js scripts)

### DIFF
--- a/invenio/base/templates/admin_base.html
+++ b/invenio/base/templates/admin_base.html
@@ -22,7 +22,6 @@
 {%- block css -%}{% block head_css %}<link href="{{ url_for('admin.static', filename='css/admin.css') }}" rel="stylesheet">{% endblock %}{%- endblock css -%}
 
 {% block header %}
-    {%- include "base/scripts.html" %}
     {{ super() }}
     {% block head_meta %}{% endblock -%}
     {% block head_tail %}{% endblock -%}


### PR DESCRIPTION
`base/scripts.html` was included twice, once in the `header` block of `admin_base.html` and once in the `_bottom_assets` block of the `page_base.html`

 fixes #664