### PR TITLE
Reject uploaded empty files via REST API

### DIFF
--- a/invenio/b2share/testsuite/test_rest_empty_files.py
+++ b/invenio/b2share/testsuite/test_rest_empty_files.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Tests for REST API: empty files"""
+
+from invenio.testsuite import make_test_suite, run_test_suite
+
+from .helpers import B2ShareAPITestCase, TemporaryDirectory, create_file
+
+from flask import current_app
+
+class TestB2ShareEmptyFiles(B2ShareAPITestCase):
+    """Unit tests for the REST API: empty files should be rejected"""
+
+    def setUp(self):
+        self.create_and_login_user()
+
+    def tearDown(self):
+        self.remove_user()
+
+    def test_rest_api_error_on_empty_file(self):
+        current_app.config.update(PRESERVE_CONTEXT_ON_EXCEPTION = False)
+
+        create_json = self.safe_create_deposition()
+        deposit_id = create_json['deposit_id']
+
+        valid_file_name = "valid.txt"
+        with TemporaryDirectory() as tmp_dir:
+            # valid file
+            file1 = create_file(tmp_dir, valid_file_name, "test file 1")
+            self.safe_upload_deposition_file(deposit_id, file1)
+
+            # empty file
+            file2 = create_file(tmp_dir, "empty.txt", "")
+            request = self.upload_deposition_file(deposit_id, file2)
+            self.assertTrue(request.status_code == 400)
+            self.assertTrue(request.json['errors'])
+
+        metadata = {
+            'domain': "generic",
+            'title': 'Empty file test',
+            'description': "Test of empty file rejection via RestAPI",
+            'open_access': "true"
+        }
+
+        # commit deposition
+        commit_json = self.safe_commit_deposition(deposit_id, metadata)
+        record_id = commit_json['record_id']
+
+        # get record and test files
+        record_json = self.safe_get_record(record_id)
+        record_files = [f.get('name') for f in record_json['files']]
+        self.assertEquals(record_files, [valid_file_name])
+
+
+TEST_SUITE = make_test_suite(TestB2ShareEmptyFiles)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
This PR introduces some (minor) changes in the REST API results, potentially breaking existing clients (of which I presume are not many, if at all). These changes are:

 - uniform id names (e.g. `deposit_id` instead of `depositID`)
 - always return a JSON top level object, not an array (useful for security of JS clients)
 - renamed incorrect `Deposit` term with `record`

This PR fixes https://github.com/EUDAT-B2SHARE/b2share/issues/667 and fixes https://github.com/EUDAT-B2SHARE/b2share/issues/558