### PR TITLE
Adding support for editing metadata, filenames, and deletion of files

### DIFF
--- a/invenio/b2share/modules/b2deposit/restful.py
+++ b/invenio/b2share/modules/b2deposit/restful.py
@@ -119,12 +119,11 @@ def get_record_details(recid, curr_user_email):
         recdocs = BibRecDocs(recid)
     except:
         current_app.logger.error("REST API: Error while building BibRecDocs for record %d" % (recid,))
-        return []
+        return {}
 
     latest_files = recdocs.list_latest_files()
     if len(latest_files) == 0:
         current_app.logger.error("REST API: BibRecDocs reports 0 files for record %d" % (recid,))
-        return []
 
     # bibformat uses get_record, usually is one db
     # hit per object; should be fastest

--- a/invenio/b2share/modules/b2deposit/static/css/b2s-deposit.css
+++ b/invenio/b2share/modules/b2deposit/static/css/b2s-deposit.css
@@ -51,6 +51,21 @@
     background-color: rgb(225, 225, 225);
 }
 
+#file-table tbody tr .file-name input {
+    color: black;
+    border: 1px solid rgb(225, 225, 225);
+    background-color: rgb(225, 225, 225);
+}
+
+#file-table tbody tr.to-delete {
+    color: #fff;
+    background-color: #c73118;
+    border-color: #d43f3a;
+}
+
+#file-table tbody tr.to-delete input {
+    color: red;
+}
 
 #domains {
     margin-top: 0px;

--- a/invenio/b2share/modules/b2deposit/templates/b2share-edit.html
+++ b/invenio/b2share/modules/b2deposit/templates/b2share-edit.html
@@ -49,17 +49,51 @@
     </div>
 
     <div class="newdeposit col-sm-8">
-
         <div>
-            <input type="hidden" id="url_for_updatemeta" name="url_for_updatemeta" value="{{ url_for('.updatemeta', recid=recid) }}"></input>
+            <input type="hidden" id="url_for_updatemeta" name="url_for_updatemeta"
+                value="{{ url_for('.updatemeta', recid=recid) }}"></input>
 
             <form class="form form-horizontal meta-form" method="post" id="metaform_form">
+
+                {% if files %}
+                <h2 style="margin-top:30px">
+                    <p>Edit files</p>
+                </h2>
+                <table id="file-table" class="table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Size</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody id="filelist">
+                        {% for file in files %}
+                        <tr>
+                            <td>
+                                <input type="text" name="{{'__file__name__{}'.format(file.id)}}"
+                                    value="{{file.name}}">
+                            </td>
+                            <td>{{file.type}}</td>
+                            <td>{{file.size}}B</td>
+                            <td>
+                                <label class="btn btn-sm btn-default file-delete">
+                                    <input type="checkbox" name="{{'__file__delete__{}'.format(file.id)}}"
+                                        value="Delete"> Delete this file
+                                </label>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div style="border-top: 2px solid #255f86;"></div>
+                {% endif %}
 
                 <div id="metaform">
                     <h2 style="margin-top:30px">
                         <p>Edit metadata</p>
                     </h2>
-                    <input type="hidden" id="sub_id" name="sub_id" value="{{ sub_id }}"/>
 
                     <div id="meta">
                         <div id="meta-fields">
@@ -68,19 +102,27 @@
                         </div>
 
                         <div id="reqfootnote" class="footnote hide">* indicates required field</div>
-
-                        <div id="submitbutton">
-                            <h2 style="margin-top:30px">
-                                <button id="update_deposit" name="action_save" class="btn btn-large btn-primary btn-block">Update</button>
-                            </h2>
-                        </div>
                     </div>
+
+                    <div id="submitbutton">
+                        <h2 style="margin-top:30px">
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <button id="update_deposit" name="action_save"
+                                        class="btn btn-large btn-primary btn-block">Update</button>
+                                </div>
+                                <div class="col-sm-6">
+                                    <a href="{{ url_for('record.metadata', recid=recid)}}" name="action_cancel"
+                                        class="btn btn-large btn-default btn-block">Cancel</a>
+                                </div>
+                            </div>
+                        </h2>
+                    </div>
+
                 </div>
 
             </form>
-
         </div>
-
     </div>
 </div>
 </div>

--- a/invenio/b2share/modules/main/static/js/b2s-deposit-editor.js
+++ b/invenio/b2share/modules/main/static/js/b2s-deposit-editor.js
@@ -20,6 +20,12 @@
 $(document).ready(function() {
     "use strict";
 
+    $('#filelist .file-delete').click(function(){
+        var $label = $(this);
+        var state = $label.find('input').is(':checked');
+        $label.closest('tr').toggleClass('to-delete', state);
+    });
+
     function update_deposit_click_handler(e) {
         e.preventDefault();
         var updatemeta_url = $("#url_for_updatemeta").attr("value");


### PR DESCRIPTION
Currently only the superadmin is allowed to change a record, but this restriction can be easily extended to other users based on groups. 

This PR is needed to solve https://github.com/EUDAT-B2SHARE/b2share/issues/532, https://github.com/EUDAT-B2SHARE/b2share/issues/531 and https://github.com/EUDAT-B2SHARE/b2share/issues/127

@nharraud Please have a look at the `bibdoc_file_list` and `bibdoc_modify_files` and tell me if I misuse the Invenio mechanisms for deleting and renaming files