### PR TITLE
base: fix settings.js syntax error

### DIFF
--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -163,6 +163,7 @@ require.config({
     "bootstrap-switch": {
       deps: ["jquery"],
       exports: "$.fn.bootstrapSwitch",
+    },
     select2: {
       deps: ["jquery"],
       exports: "select2"


### PR DESCRIPTION
* Fix an error introduced in 9333fe8d558303f255128b38702d67b1ef5f599d
  invenio/maint-2.0 merge

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>