### PR TITLE
Fixed doubled titled and descriptions in search page

### DIFF
--- a/invenio/modules/formatter/templates/format/record/Default_HTML_brief.tpl
+++ b/invenio/modules/formatter/templates/format/record/Default_HTML_brief.tpl
@@ -27,7 +27,6 @@
 
 {% block record_header %}
   <a href="{{ url_for('record.metadata', recid=record['recid']) }}">
-    {{ bfe_title(bfo) }}
     {{ record.get('title.title', '') }}
     {{- record.get('title.volume', '')|prefix(', ') }}
     {{- record.get('title.subtitle', '')|prefix(': ') }}
@@ -36,7 +35,6 @@
 {% endblock %}
 
 {% block record_content %}
-  {{ bfe_abstract(bfo, limit="3") }}
   {{ record.get('abstract.summary', '')|sentences(3) }}
 {% endblock %}
 


### PR DESCRIPTION
The `bfe_` lines had been included by me after switching to a new Invenio version because the `record` object, at that time, did not contain any useful data. Now the `record` object works properly and the `bfe_` legacy calls can be removed.  

See #748 