### PR TITLE
alternative installation with docker-compse works again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,15 @@ RUN apt-get update && \
     apt-get -qy install --fix-missing --no-install-recommends \
         gcc \
         git \
+        libcurl4-gnutls-dev \
         libffi-dev \
+        libjpeg-dev \
         libmysqlclient-dev \
+        libpython-dev \
         libssl-dev \
         libxslt-dev \
         mysql-client \
+        python-dev \
         nodejs \
         poppler-utils \
         subversion \
@@ -90,8 +94,7 @@ WORKDIR /code
 RUN python requirements.py --extras=$REXTRAS --level=min > requirements.py.lowest.txt && \
     python requirements.py --extras=$REXTRAS --level=pypi > requirements.py.release.txt && \
     python requirements.py --extras=$REXTRAS --level=dev > requirements.py.devel.txt && \
-    pip install -r requirements.py.$REQUIREMENTS.txt --allow-all-external --quiet
-
+    pip install -r requirements.py.$REQUIREMENTS.txt --allow-all-external 
 
 ###############################################################################
 ## 3. Code (changing)                                                        ##
@@ -107,6 +110,8 @@ COPY . /code
 
 # install invenio
 RUN pip install -e .[$REXTRAS] --quiet
+# add b2share requirements:
+RUN pip install -r requirements-b2share.txt
 
 # build translation catalog
 RUN python setup.py compile_catalog
@@ -145,4 +150,3 @@ ENTRYPOINT ["/code/scripts/docker_boot.sh"]
 
 # default to bash
 CMD ["bash"]
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,5 @@ mysql:
   environment:
     - MYSQL_DATABASE=invenio
     - MYSQL_USER=invenio
-    - MYSQL_PASSWORD=my123p$ss
+    - MYSQL_PASSWORD=my123pss
     - MYSQL_ROOT_PASSWORD=mysecretpassword


### PR DESCRIPTION
adding additional dependencies in Dockerfile (both apt-get and pip)  rendered docker build successful.
fixes in docker-compose (old mysql password was wrongly interpreted).

All in all it makes alternative installation possible:
docker-compose build
docker-compose up

