### PR TITLE
demo: fixed UUID for demo and test data loading

### DIFF
--- a/b2share/modules/communities/api.py
+++ b/b2share/modules/communities/api.py
@@ -100,7 +100,7 @@ class Community(object):
         return [cls(md) for md in metadata]
 
     @classmethod
-    def create_community(cls, name, description, logo=None):
+    def create_community(cls, name, description, logo=None, id_=None):
         """Create a new Community.
 
         A new community is implicitly associated with a new, empty, schema
@@ -121,8 +121,11 @@ class Community(object):
         from .models import Community as CommunityMetadata
         try:
             with db.session.begin_nested():
+                kwargs = {}
+                if id_ is not None:
+                    kwargs['id'] = id_
                 model = CommunityMetadata(name=name, description=description,
-                                          logo=logo)
+                                          logo=logo, **kwargs)
                 community = cls(model)
                 before_community_insert.send(community)
                 db.session.add(model)

--- a/b2share/modules/schemas/api.py
+++ b/b2share/modules/schemas/api.py
@@ -174,7 +174,7 @@ class BlockSchema(object):
             raise BlockSchemaDoesNotExistError() from e
 
     @classmethod
-    def create_block_schema(cls, community_id, name):
+    def create_block_schema(cls, community_id, name, id_=None):
         """Create a new block schema.
 
         Args:
@@ -183,8 +183,11 @@ class BlockSchema(object):
         from .models import BlockSchema as BlockSchemaModel
         try:
             with db.session.begin_nested():
+                kwargs = {}
+                if id_ is not None:
+                    kwargs['id'] = id_
                 model = BlockSchemaModel(
-                    community=community_id, name=name)
+                    community=community_id, name=name, **kwargs)
                 block_schema = cls(model)
                 db.session.add(model)
         except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.DataError) as e:

--- a/demo/b2share_demo/data/communities/bbmri.json
+++ b/demo/b2share_demo/data/communities/bbmri.json
@@ -1,6 +1,7 @@
 {
     "name": "BBMRI",
     "description": "BBMRI community.",
+    "id": "99916f6f-9a2c-4feb-a342-6552ac7f1529",
     "community_schemas": [
         {
             "root_schema_version": 0,
@@ -19,6 +20,7 @@
     ],
     "block_schemas": {
         "bbmri": {
+            "id": "362e6f81-68fb-4d71-9496-34ca00e59769",
             "versions": [
                 {
                     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/demo/b2share_demo/helpers.py
+++ b/demo/b2share_demo/helpers.py
@@ -74,7 +74,8 @@ def _create_communities(path, verbose):
                     json_config = json.loads(json_file.read())
                     community = Community.create_community(
                         name=json_config['name'],
-                        description=json_config['description']
+                        description=json_config['description'],
+                        id_=UUID(json_config['id']),
                     )
                     if verbose > 1:
                         click.secho('Created community {0} with ID {1}'.format(
@@ -100,7 +101,9 @@ def _create_block_schemas(communities, verbose):
                     'block_schemas'].items():
                 block_schema = BlockSchema.create_block_schema(
                     community.ref.id,
-                    schema_name)
+                    schema_name,
+                    id_=UUID(schema['id']),
+                )
                 for json_schema in schema['versions']:
                     block_schema.create_version(json_schema)
                 nb_block_schemas += 1

--- a/tests/data/communities/my_test_community.json
+++ b/tests/data/communities/my_test_community.json
@@ -1,6 +1,7 @@
 {
     "name": "MyTestCommunity",
     "description": "Test community.",
+    "id": "2b884138-898f-4651-bf82-34dea0e0e83f",
     "community_schemas": [
         {
             "root_schema_version": 0,
@@ -19,6 +20,7 @@
     ],
     "block_schemas": {
         "MyTestSchema": {
+            "id": "38e12922-a361-49a1-853b-92a6863bfa58",
             "versions": [
                 {
                     "$schema": "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
* Adds a mandatory UUID for demonstration and test communities and
  their schemas. This enables easier demonstration.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>