### PR TITLE
global: deposit publication workflow support

### DIFF
--- a/b2share/modules/deposit/errors.py
+++ b/b2share/modules/deposit/errors.py
@@ -23,8 +23,14 @@
 
 """B2Share Deposit errors."""
 
+
 class B2ShareDepositError(Exception):
     """B2Share Deposit module Exception."""
 
+
 class InvalidDepositDataError(B2ShareDepositError):
     """Exception raised when the deposit data is invalid."""
+
+
+class InvalidDepositStateError(B2ShareDepositError):
+    """Exception raised when the publication_state transition is invalid."""

--- a/b2share/modules/deposit/links.py
+++ b/b2share/modules/deposit/links.py
@@ -24,31 +24,34 @@
 """B2Share Deposit Link factory."""
 
 from flask import url_for, g
+from b2share.modules.records.providers import RecordUUIDProvider
 
-# def deposit_links_factory(record):
-#     """Factory for record links generation."""
-#     def links_factory(pid):
 
 def deposit_links_factory(pid):
     """Factory for record links generation."""
-    endpoint = 'b2share_deposit_rest.{0}_item'.format(pid.pid_type)
-    links = dict(self=url_for(endpoint, pid_value=pid.pid_value,
-                _external=True))
+    deposit_endpoint = 'b2share_deposit_rest.{0}_item'.format(pid.pid_type)
+    record_endpoint = 'b2share_records_rest.{0}_item'.format(
+        RecordUUIDProvider.pid_type
+    )
+    links = dict(
+        self=url_for(deposit_endpoint, pid_value=pid.pid_value,
+                     _external=True),
+        publication=url_for(record_endpoint, pid_value=pid.pid_value,
+                            _external=True)
+    )
 
     def _url(name, **kwargs):
         """URL builder."""
         endpoint = 'b2share_deposit_rest.{0}_{1}'.format(pid.pid_type, name)
         return url_for(endpoint, pid_value=pid.pid_value, _external=True,
-                    **kwargs)
+                       **kwargs)
 
     if hasattr(g, 'record'):
         record = g.record
         # FIXME: index the record bucket with the bucket so that we can
         # add the "files" link
-        links['files'] = url_for('invenio_files_rest.bucket_api',
-                                    bucket_id=record.files.bucket,
-                                    _external=True)
-    for action in ('publish', 'edit', 'discard'):
-        links[action] = _url('actions', action=action)
+        if record.files is not None:
+            links['files'] = url_for('invenio_files_rest.bucket_api',
+                                     bucket_id=record.files.bucket,
+                                     _external=True)
     return links
-    # return links_factory

--- a/b2share/modules/deposit/serializers/__init__.py
+++ b/b2share/modules/deposit/serializers/__init__.py
@@ -30,8 +30,7 @@ from b2share.modules.records.serializers.schemas.json import DraftSchemaJSONV1
 
 from b2share.modules.records.serializers.response import record_responsify, \
     JSONSerializer
-from b2share.modules.deposit.links import deposit_links_factory
 
-json_v1 = JSONSerializer(deposit_links_factory, DraftSchemaJSONV1)
+json_v1 = JSONSerializer(DraftSchemaJSONV1)
 json_v1_response = record_responsify(json_v1, 'application/json')
 json_v1_search = search_responsify(json_v1, 'application/json')

--- a/b2share/modules/deposit/views.py
+++ b/b2share/modules/deposit/views.py
@@ -1,55 +1,40 @@
 
-import json
-from copy import deepcopy
 from functools import partial
 
-from flask import Blueprint, abort, make_response, request, url_for
-from werkzeug.utils import secure_filename
-from invenio_db import db
+from flask import Blueprint, current_app
 from invenio_files_rest.errors import InvalidOperationError
-from invenio_oauth2server import require_api_auth, require_oauth_scopes
 from invenio_pidstore.errors import PIDInvalidAction
 from invenio_pidstore.resolver import Resolver
 from invenio_records_rest.utils import obj_or_import_string
-from invenio_records_rest.views import need_record_permission, pass_record
-from invenio_rest import ContentNegotiatedMethodView
 from invenio_rest.views import create_api_errorhandler
-from webargs import fields
-from webargs.flaskparser import use_kwargs
-from flask import Blueprint, current_app, jsonify, url_for
-from invenio_rest.views import ContentNegotiatedMethodView
-from b2share.modules.schemas.views import pass_community_schema
-from b2share.modules.schemas.serializers import \
-    community_schema_json_schema_link
 from werkzeug.local import LocalProxy
-from invenio_records_rest.views import RecordsListResource
 from invenio_records_rest.links import default_links_factory
-from invenio_records.api import Record
 from invenio_records_rest.views import RecordResource
-from invenio_deposit.views.rest import DepositActionResource
 from invenio_deposit.search import DepositSearch
 from invenio_deposit.api import Deposit as InvenioDeposit
+
 
 current_jsonschemas = LocalProxy(
     lambda: current_app.extensions['invenio-jsonschemas']
 )
 
+
 def records_rest_url_rules(endpoint, list_route=None, item_route=None,
-                     pid_type=None, pid_minter=None, pid_fetcher=None,
-                     read_permission_factory_imp=None,
-                     create_permission_factory_imp=None,
-                     update_permission_factory_imp=None,
-                     delete_permission_factory_imp=None,
-                     record_class=None,
-                     record_serializers=None,
-                     record_loaders=None,
-                     search_class=None,
-                     search_serializers=None,
-                     search_index=None, search_type=None,
-                     default_media_type=None,
-                     max_result_window=None, use_options_view=True,
-                     search_factory_imp=None, links_factory_imp=None,
-                     suggesters=None, **kwargs):
+                           pid_type=None, pid_minter=None, pid_fetcher=None,
+                           read_permission_factory_imp=None,
+                           create_permission_factory_imp=None,
+                           update_permission_factory_imp=None,
+                           delete_permission_factory_imp=None,
+                           record_class=None,
+                           record_serializers=None,
+                           record_loaders=None,
+                           search_class=None,
+                           search_serializers=None,
+                           search_index=None, search_type=None,
+                           default_media_type=None,
+                           max_result_window=None, use_options_view=True,
+                           search_factory_imp=None, links_factory_imp=None,
+                           suggesters=None, **kwargs):
     """Create Werkzeug URL rules.
 
     :param endpoint: Name of endpoint.
@@ -86,9 +71,6 @@ def records_rest_url_rules(endpoint, list_route=None, item_route=None,
     read_permission_factory = obj_or_import_string(
         read_permission_factory_imp
     )
-    create_permission_factory = obj_or_import_string(
-        create_permission_factory_imp
-    )
     update_permission_factory = obj_or_import_string(
         update_permission_factory_imp
     )
@@ -99,7 +81,10 @@ def records_rest_url_rules(endpoint, list_route=None, item_route=None,
         links_factory_imp, default=default_links_factory
     )
     record_class = obj_or_import_string(
-        record_class, default=Record
+        record_class, default=InvenioDeposit
+    )
+    search_class = obj_or_import_string(
+        search_class, default=DepositSearch
     )
 
     if record_loaders:
@@ -130,6 +115,7 @@ def records_rest_url_rules(endpoint, list_route=None, item_route=None,
         dict(rule=item_route, view_func=item_view),
     ]
 
+
 def create_blueprint(endpoints):
     """Create Invenio-Deposit-REST blueprint."""
     blueprint = Blueprint(
@@ -145,181 +131,7 @@ def create_blueprint(endpoints):
     ))
 
     for endpoint, options in (endpoints or {}).items():
-        options = deepcopy(options)
-
-        # if 'files_serializers' in options:
-        #     files_serializers = options.get('files_serializers')
-        #     files_serializers = {mime: obj_or_import_string(func)
-        #                          for mime, func in files_serializers.items()}
-        #     del options['files_serializers']
-        # else:
-        #     files_serializers = {}
-
-        if 'record_serializers' in options:
-            serializers = options.get('record_serializers')
-            serializers = {mime: obj_or_import_string(func)
-                           for mime, func in serializers.items()}
-        else:
-            serializers = {}
-
-        # file_list_route = options.pop(
-        #     'file_list_route',
-        #     '{0}/files'.format(options['item_route'])
-        # )
-        # file_item_route = options.pop(
-        #     'file_item_route',
-        #     '{0}/files/<path:key>'.format(options['item_route'])
-        # )
-
         for rule in records_rest_url_rules(endpoint, **options):
             blueprint.add_url_rule(**rule)
 
-        search_class = obj_or_import_string(
-            options['search_class'], default=DepositSearch
-        )
-        record_class = obj_or_import_string(
-            options['record_class'], default=InvenioDeposit
-        )
-
-        search_class_kwargs = {}
-        if options.get('search_index'):
-            search_class_kwargs['index'] = options['search_index']
-
-        if options.get('search_type'):
-            search_class_kwargs['doc_type'] = options['search_type']
-
-        ctx = dict(
-            read_permission_factory=obj_or_import_string(
-                options.get('read_permission_factory_imp')
-            ),
-            create_permission_factory=obj_or_import_string(
-                options.get('create_permission_factory_imp')
-            ),
-            update_permission_factory=obj_or_import_string(
-                options.get('update_permission_factory_imp')
-            ),
-            delete_permission_factory=obj_or_import_string(
-                options.get('delete_permission_factory_imp')
-            ),
-            search_class=partial(search_class, **search_class_kwargs),
-            default_media_type=options.get('default_media_type'),
-            record_class=record_class,
-        )
-
-        deposit_actions = DepositActionResource.as_view(
-            DepositActionResource.view_name.format(endpoint),
-            serializers=serializers,
-            pid_type=options['pid_type'],
-            ctx=ctx,
-        )
-
-        blueprint.add_url_rule(
-            '{0}/actions/<any(publish,edit,discard):action>'.format(
-                options['item_route']
-            ),
-            view_func=deposit_actions,
-            methods=['POST'],
-        )
-
-
-        # deposit_files = DepositFilesResource.as_view(
-        #     DepositFilesResource.view_name.format(endpoint),
-        #     serializers=files_serializers,
-        #     pid_type=options['pid_type'],
-        #     ctx=ctx,
-        # )
-
-        # blueprint.add_url_rule(
-        #     file_list_route,
-        #     view_func=deposit_files,
-        #     methods=['GET', 'POST', 'PUT'],
-        # )
-
-        # deposit_file = DepositFileResource.as_view(
-        #     DepositFileResource.view_name.format(endpoint),
-        #     serializers=files_serializers,
-        #     pid_type=options['pid_type'],
-        #     ctx=ctx,
-        # )
-
-        # blueprint.add_url_rule(
-        #     file_item_route,
-        #     view_func=deposit_file,
-        #     methods=['GET', 'PUT', 'DELETE'],
-        # )
-    blueprint.add_url_rule(
-        '/communities/<string:community_id>/schemas/<string:schema_version_nb>/deposit',
-        view_func=CommunityDepositSchemaResource.as_view(
-            CommunityDepositSchemaResource.view_name,
-        ),
-        methods=['GET'],
-    )
     return blueprint
-
-def community_deposit_schema_to_json_serializer(deposit_schema, code=200,
-                                                headers=None):
-    response = jsonify(deposit_schema_to_dict(deposit_schema))
-    response.status_code = code
-    response.set_etag(
-        str(deposit_schema.community_schema.released.utcfromtimestamp(0)))
-    if headers is not None:
-        response.headers.extend(headers)
-    return response
-
-def deposit_schema_to_dict(deposit_schema):
-    return dict(
-        json_schema=deposit_schema.json_schema,
-        links={
-            'self': '{}#/json_schema'.format(url_for(
-            'b2share_deposit_rest.community_deposit_schema',
-            community_id=deposit_schema.community_schema.community,
-            schema_version_nb=deposit_schema.community_schema.version,
-            _external=True))
-        }
-    )
-
-class CommunityDepositSchema(object):
-    def __init__(self, community_schema):
-        self.community_schema = community_schema
-
-    @property
-    def json_schema(self):
-        return {
-            '$schema': 'http://json-schema.org/draft-04/schema#',
-            'title': 'B2Share Deposit schema',
-            'allOf': [{
-                '$ref':
-                community_schema_json_schema_link(self.community_schema)
-            }, {
-                '$ref':
-                current_jsonschemas.path_to_url(
-                    'deposits/deposit-v1.0.0.json')
-            }]
-        }
-class CommunityDepositSchemaResource(ContentNegotiatedMethodView):
-    view_name = 'community_deposit_schema'
-
-    def __init__(self, **kwargs):
-        """Constructor."""
-        super(CommunityDepositSchemaResource, self).__init__(
-            serializers={
-                'application/json':
-                community_deposit_schema_to_json_serializer,
-            },
-            default_method_media_type={
-                'GET': 'application/json',
-            },
-            default_media_type='application/json',
-            **kwargs
-        )
-    @pass_community_schema
-    def get(self, community_schema, *args, **kwargs):
-        return CommunityDepositSchema(community_schema)
-
-# blueprint.add_url_rule(
-#     '/communities/<string:community_id>/schemas/<string:schema_version_nb>/deposit',
-#     view_func=CommunityDepositSchemaResource.as_view(record
-#         CommunityDepositSchemaResource.view_name,
-#     ),
-#     methods=['GET'],
-# )

--- a/b2share/modules/records/links.py
+++ b/b2share/modules/records/links.py
@@ -32,27 +32,25 @@ RECORD_BUCKET_RELATION_TYPE = \
     'http://b2share.eudat.eu/relation_types/record_bucket'
 """Relation type used for a record's submission bucket links."""
 
+
 def http_header_link_regex(relation_type):
     """Create a regex matching the http header links of the given type."""
     return re.compile(r'.*;+\s*rel="{}"\s*(;.*)?'.format(
         re.escape(relation_type)))
 
 
-# def record_links_factory(record):
-#     """Factory for record links generation."""
-#     def links_factory(pid):
 def record_links_factory(pid):
     """Factory for record links generation."""
     endpoint = 'b2share_records_rest.{0}_item'.format(pid.pid_type)
     links = dict(self=url_for(endpoint, pid_value=pid.pid_value,
-                _external=True))
+                              _external=True))
 
     if hasattr(g, 'record'):
         record = g.record
         # FIXME: index the record bucket with the bucket so that we can
         # add the "files" link
-        links['files'] = url_for('invenio_files_rest.bucket_api',
-                                    bucket_id=record.files.bucket,
-                                    _external=True)
+        if record.files is not None:
+            links['files'] = url_for('invenio_files_rest.bucket_api',
+                                     bucket_id=record.files.bucket,
+                                     _external=True)
     return links
-    # return links_factory

--- a/b2share/modules/records/serializers/__init__.py
+++ b/b2share/modules/records/serializers/__init__.py
@@ -25,14 +25,12 @@
 
 from __future__ import absolute_import, print_function
 
-# from invenio_records_rest.serializers.json import JSONSerializer
 from invenio_records_rest.serializers.response import search_responsify
 from b2share.modules.records.serializers.schemas.json import RecordSchemaJSONV1
 
 from b2share.modules.records.serializers.response import record_responsify, \
     JSONSerializer
-from b2share.modules.records.links import record_links_factory
 
-json_v1 = JSONSerializer(record_links_factory, RecordSchemaJSONV1)
+json_v1 = JSONSerializer(RecordSchemaJSONV1)
 json_v1_response = record_responsify(json_v1, 'application/json')
 json_v1_search = search_responsify(json_v1, 'application/json')

--- a/b2share/modules/records/serializers/schemas/json.py
+++ b/b2share/modules/records/serializers/schemas/json.py
@@ -25,31 +25,27 @@
 
 from marshmallow import Schema, fields, pre_dump
 
+
 class DraftSchemaJSONV1(Schema):
-    """Schema for drafts v1 in JSON."""
-
-    id = fields.String(attribute='pid.pid_value')
-    metadata = fields.Raw()
-    links = fields.Raw()
-    created = fields.Str()
-    updated = fields.Str()
-
-    # @pre_dump
-    # def filter_internal(self, data):
-    #     """Remove '_internal' field from the record metadata."""
-    #     del data['metadata']['_internal']
-
-class RecordSchemaJSONV1(Schema):
     """Schema for records v1 in JSON."""
 
     id = fields.String(attribute='pid.pid_value')
     metadata = fields.Raw()
     links = fields.Raw()
-    files = fields.Raw()
     created = fields.Str()
     updated = fields.Str()
 
-    # @pre_dump
-    # def filter_internal(self, data):
-    #     """Remove '_internal' field from the record metadata."""
-    #     del data['metadata']['_internal']
+    @pre_dump
+    def filter_internal(self, data):
+        """Remove internal fields from the record metadata."""
+        data['metadata']['owners'] = data['metadata']['_deposit']['owners']
+        del data['metadata']['_deposit']
+        if '_files' in data['metadata']:
+            del data['metadata']['_files']
+        if '_pid' in data['metadata']:
+            del data['metadata']['_pid']
+        return data
+
+
+class RecordSchemaJSONV1(DraftSchemaJSONV1):
+    """Schema for drafts v1 in JSON."""

--- a/b2share/modules/records/views.py
+++ b/b2share/modules/records/views.py
@@ -22,26 +22,16 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
-import copy
 import uuid
-from functools import partial, wraps
+from functools import partial
 
-from flask import Blueprint, abort, current_app, jsonify, make_response, \
-    request, url_for
-from flask.views import MethodView
+from flask import Blueprint, abort, request, url_for
 from invenio_db import db
-from invenio_pidstore import current_pidstore
-from invenio_pidstore.models import PersistentIdentifier
 from invenio_pidstore.resolver import Resolver
 from invenio_records_files.api import Record
-from invenio_rest import ContentNegotiatedMethodView
-from invenio_rest.decorators import require_content_types
 from invenio_rest.errors import RESTValidationError
 from invenio_search import RecordsSearch
-from jsonpatch import JsonPatchException, JsonPointerException
 from jsonschema.exceptions import ValidationError
-from sqlalchemy.exc import SQLAlchemyError
-from werkzeug.local import LocalProxy
 from invenio_records_rest.views import (RecordsListResource, RecordResource,
                                         RecordsListOptionsResource,
                                         SuggestResource)
@@ -49,9 +39,8 @@ from invenio_records_rest.links import default_links_factory
 from invenio_records_rest.query import default_search_factory
 from invenio_records_rest.utils import obj_or_import_string
 from invenio_records_rest.views import verify_record_permission
-from b2share.modules.deposit.api import Deposit
-from invenio_records.api import Record
 from b2share.modules.deposit.links import deposit_links_factory
+
 
 def create_blueprint(endpoints):
     """Create Invenio-Records-REST blueprint."""
@@ -171,6 +160,9 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
     resolver = Resolver(pid_type=pid_type, object_type='rec',
                         getter=partial(record_class.get_record,
                                        with_deleted=True))
+
+    # import deposit here in order to avoid dependency loop
+    from b2share.modules.deposit.api import Deposit
 
     list_view = B2shareRecordsListResource.as_view(
         RecordsListResource.view_name.format(endpoint),

--- a/b2share/modules/schemas/jsonresolver.py
+++ b/b2share/modules/schemas/jsonresolver.py
@@ -30,8 +30,6 @@ import jsonresolver
 from werkzeug.routing import Rule
 
 from .api import BlockSchema, CommunitySchema
-from b2share.modules.deposit.views import deposit_schema_to_dict, \
-    CommunityDepositSchema
 from .serializers import block_schema_version_to_dict, community_schema_to_dict
 
 
@@ -53,26 +51,16 @@ def jsonresolver_loader(url_map):
             version=schema_version_nb)
         return community_schema_to_dict(community_schema)
 
-    def community_deposit_resolver(community_id, schema_version_nb):
-        community_schema = CommunitySchema.get_community_schema(
-            community_id=community_id,
-            version=schema_version_nb)
-        return deposit_schema_to_dict(CommunityDepositSchema(community_schema))
     url_map.add(Rule(
         '{}/communities/<string:community_id>/schemas/'
         '<int:schema_version_nb>'.format(
             current_app.config.get('APPLICATION_ROOT') or ''),
         endpoint=community_resolver,
         host=current_app.config['SERVER_NAME']))
-    url_map.add(Rule(
-        '{}/communities/<string:community_id>/schemas/'
-        '<int:schema_version_nb>/deposit'.format(
-            current_app.config.get('APPLICATION_ROOT') or ''),
-        endpoint=community_deposit_resolver,
-        host=current_app.config['SERVER_NAME']))
+
     url_map.add(Rule(
         '{}/schemas/<string:schema_id>/versions'
         '/<int:schema_version_nb>'.format(
-            current_app.config.get('APPLICATION_ROOT') or '' ),
+            current_app.config.get('APPLICATION_ROOT') or ''),
         endpoint=block_schema_resolver,
         host=current_app.config['SERVER_NAME']))

--- a/b2share/modules/schemas/root_schemas/root_schema_v0.json
+++ b/b2share/modules/schemas/root_schemas/root_schema_v0.json
@@ -5,6 +5,12 @@
         "type": "object",
         "properties": {
             "$schema": { "type": "string" },
+            "publication_state": {
+                "title": "Publication State",
+                "description": "State of the publication workflow.",
+                "type": "string",
+                "enum": [ "draft", "submitted", "published" ]
+            },
             "owner": {
                 "title": "Owner",
                 "description": "Identifier of the user that owns the record",

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,11 @@ install_requires = [
     'invenio-deposit>=1.0.0a1,<1.1.0',
 ]
 
-if sys.version_info < (3,4):
+if sys.version_info < (3, 4):
     # In Python 3.4, pathlib is now part of the standard library.
     install_requires += ["pathlib >= 1.0.1"]
+    # Backport of Python 3.4 enums to earlier versions
+    install_requires.append('enum34>=1.1.6')
 
 tests_require = [
     'check-manifest>=0.25',
@@ -166,7 +168,8 @@ setup(
         ],
         'invenio_base.api_blueprints': [
             'invenio_oauthclient = invenio_oauthclient.views.client:blueprint',
-            # 'b2share_deposit = b2share.modules.deposit.views:blueprint',
+            'b2share_communities = '
+            'b2share.modules.communities.views:blueprint',
         ],
         'invenio_db.models': [
             'b2share_communities = b2share.modules.communities.models',

--- a/tests/b2share_unit_tests/deposit/test_deposit_api.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_api.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EUDAT B2Share.
+# Copyright (C) 2016 CERN.
+#
+# B2Share is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# B2Share is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with B2Share; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test B2Share deposit module's programmatic API."""
+
+import pytest
+from b2share.modules.deposit.api import Deposit, PublicationStates
+from jsonschema.exceptions import ValidationError
+
+
+def test_deposit_create(app, test_deposits):
+    """Test deposit creation."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        assert (deposit['publication_state']
+                == PublicationStates.draft.name)
+        assert (deposit['_deposit']['status'] == 'draft')
+
+
+def test_deposit_submit(app, test_deposits):
+    """Test deposit submission."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        deposit.submit()
+        assert (deposit['publication_state']
+                == PublicationStates.submitted.name)
+        assert (deposit['_deposit']['status'] == 'draft')
+
+
+def test_deposit_update_and_submit(app, test_deposits):
+    """Test deposit submission by updating the "publication_state" field."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        deposit.update({'publication_state':
+                        PublicationStates.submitted.name})
+        deposit.commit()
+        assert (deposit['publication_state']
+                == PublicationStates.submitted.name)
+        assert (deposit['_deposit']['status'] == 'draft')
+
+
+def test_deposit_publish(app, test_deposits):
+    """Test deposit submission by updating the "publication_state" field."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        deposit.submit()
+        deposit.publish()
+        assert (deposit['publication_state']
+                == PublicationStates.published.name)
+        assert (deposit['_deposit']['status'] == 'published')
+
+
+def test_deposit_update_and_publish(app, test_deposits):
+    """Test deposit submission by updating the "publication_state" field."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        deposit.submit()
+        deposit.update({'publication_state':
+                        PublicationStates.published.name})
+        deposit.commit()
+        assert (deposit['publication_state']
+                == PublicationStates.published.name)
+        assert (deposit['_deposit']['status'] == 'published')
+
+
+def test_deposit_update_unknown_publication_state(app, test_deposits):
+    """Test deposit submission by updating the "publication_state" field."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        deposit.update({'publication_state':
+                        'invalid_state'})
+        with pytest.raises(ValidationError):
+            deposit.commit()

--- a/tests/b2share_unit_tests/deposit/test_deposit_rest.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_rest.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EUDAT B2Share.
+# Copyright (C) 2016 CERN.
+#
+# B2Share is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# B2Share is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with B2Share; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test B2Share deposit module's REST API."""
+
+import json
+
+import pytest
+from flask import url_for
+from b2share.modules.deposit.api import PublicationStates, Deposit
+from copy import deepcopy
+from b2share_unit_tests.helpers import subtest_self_link
+from b2share.modules.records.providers import RecordUUIDProvider
+
+
+def build_expected_metadata(record_data, state, owners=None):
+    expected_metadata = deepcopy(record_data)
+    expected_metadata['publication_state'] = state
+    expected_metadata['$schema'] = '{}#/json_schema'.format(
+        url_for('b2share_schemas.community_schema_item',
+                community_id=record_data['community'],
+                schema_version_nb=1,
+                _external=True)
+    )
+    if owners is not None:
+        expected_metadata['owners'] = owners
+    return expected_metadata
+
+
+@pytest.mark.parametrize('test_users', [({
+    'users': ['myuser']
+})], indirect=['test_users'])
+def test_deposit_create(app, test_records_data, test_users, login_user):
+    """Test record draft creation."""
+    with app.app_context():
+        with app.test_client() as client:
+            user = test_users['myuser']
+            login_user(user, client)
+            # create the deposit
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            for record_data in test_records_data:
+                record_list_url = (
+                    lambda **kwargs:
+                    url_for('b2share_records_rest.b2share_record_list',
+                            **kwargs))
+                draft_create_res = client.post(record_list_url(),
+                                               data=json.dumps(record_data),
+                                               headers=headers)
+                assert draft_create_res.status_code == 201
+                draft_create_data = json.loads(
+                    draft_create_res.get_data(as_text=True))
+                expected_metadata = build_expected_metadata(
+                    record_data,
+                    PublicationStates.draft.name,
+                    owners=[user.id],
+                )
+                assert expected_metadata == draft_create_data['metadata']
+                subtest_self_link(draft_create_data,
+                                  draft_create_res.headers,
+                                  client)
+
+
+@pytest.mark.parametrize('test_users, test_deposits', [({
+    'users': ['myuser']
+}, {
+    'deposits_creator': 'myuser'
+})], indirect=['test_users', 'test_deposits'])
+def test_deposit_submit(app, test_records_data, test_deposits, test_users,
+                        login_user):
+    """Test record draft submit with HTTP PATCH."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        record_data = test_records_data[0]
+        with app.test_client() as client:
+            user = test_users['myuser']
+            login_user(user, client)
+
+            headers = [('Content-Type', 'application/json-patch+json'),
+                       ('Accept', 'application/json')]
+            draft_patch_res = client.patch(
+                url_for('b2share_deposit_rest.b2share_deposit_item',
+                        pid_value=deposit.pid.pid_value),
+                data=json.dumps([{
+                    "op": "replace", "path": "/publication_state",
+                    "value": PublicationStates.submitted.name
+                }]),
+                headers=headers)
+            assert draft_patch_res.status_code == 200
+            draft_patch_data = json.loads(
+                draft_patch_res.get_data(as_text=True))
+            expected_metadata = build_expected_metadata(
+                record_data,
+                PublicationStates.draft.name,
+                owners=[user.id],
+            )
+
+            expected_metadata['publication_state'] = \
+                PublicationStates.submitted.name
+            assert expected_metadata == draft_patch_data['metadata']
+            deposit = Deposit.get_record(test_deposits[0])
+            assert (deposit['publication_state']
+                    == PublicationStates.submitted.name)
+            subtest_self_link(draft_patch_data,
+                              draft_patch_res.headers,
+                              client)
+
+
+@pytest.mark.parametrize('test_users, test_deposits', [({
+    'users': ['myuser']
+}, {
+    'deposits_creator': 'myuser'
+})], indirect=['test_users', 'test_deposits'])
+def test_deposit_publish(app, test_records_data, test_deposits, test_users,
+                         login_user):
+    """Test record draft publication with HTTP PATCH."""
+    with app.app_context():
+        deposit = Deposit.get_record(test_deposits[0])
+        record_data = test_records_data[0]
+        with app.test_client() as client:
+            user = test_users['myuser']
+            login_user(user, client)
+
+            headers = [('Content-Type', 'application/json-patch+json'),
+                       ('Accept', 'application/json')]
+            draft_patch_res = client.patch(
+                url_for('b2share_deposit_rest.b2share_deposit_item',
+                        pid_value=deposit.pid.pid_value),
+                data=json.dumps([{
+                    "op": "replace", "path": "/publication_state",
+                    "value": PublicationStates.published.name
+                }]),
+                headers=headers)
+            assert draft_patch_res.status_code == 200
+            draft_patch_data = json.loads(
+                draft_patch_res.get_data(as_text=True))
+            expected_metadata = build_expected_metadata(
+                record_data,
+                PublicationStates.published.name,
+                owners=[user.id],
+            )
+            deposit = Deposit.get_record(test_deposits[0])
+            assert expected_metadata == draft_patch_data['metadata']
+            assert (deposit['publication_state']
+                    == PublicationStates.published.name)
+            subtest_self_link(draft_patch_data,
+                              draft_patch_res.headers,
+                              client)
+
+            pid, published = deposit.fetch_published()
+            # check that the published record and the deposit are equal
+            assert dict(**published) == dict(**deposit)
+            # check "published" link
+            assert draft_patch_data['links']['publication'] == \
+                url_for('b2share_records_rest.{0}_item'.format(
+                    RecordUUIDProvider.pid_type
+                ), pid_value=pid.pid_value, _external=True)
+            # check that the published record content match the deposit
+            headers = [('Accept', 'application/json')]
+            self_response = client.get(
+                draft_patch_data['links']['publication'],
+                headers=headers
+            )
+            assert self_response.status_code == 200
+            published_data = json.loads(self_response.get_data(
+                as_text=True))
+            # we don't want to compare the links and dates
+            cleaned_published_data = deepcopy(published_data)
+            cleaned_draft_data = deepcopy(draft_patch_data)
+            for item in [cleaned_published_data, cleaned_draft_data]:
+                del item['links']
+                del item['created']
+                del item['updated']
+            assert cleaned_draft_data == cleaned_published_data

--- a/tests/b2share_unit_tests/helpers.py
+++ b/tests/b2share_unit_tests/helpers.py
@@ -24,8 +24,12 @@
 """Test helpers."""
 
 import json
+from contextlib import contextmanager
 
+from flask import current_app
 from six import string_types
+from flask_login import login_user, logout_user
+from invenio_accounts.models import User
 
 
 def subtest_self_link(response_data, response_headers, client):
@@ -44,3 +48,17 @@ def subtest_self_link(response_data, response_headers, client):
     assert self_data == response_data
     if response_headers:
         assert response_headers['ETag'] == self_response.headers['ETag']
+
+
+@contextmanager
+def authenticated_user(userinfo):
+    """Authentication context manager."""
+    user = User.query.filter(User.id == userinfo.id).one()
+    with current_app.test_request_context():
+        login_user(user)
+        try:
+            yield
+        finally:
+            logout_user()
+
+


### PR DESCRIPTION
* NEW Adds Deposit publication workflow and support it with programmatic
  and REST API.

* Cleans unused code.

* Lets invenio-deposit set the deposit owner. Remove unused trigger.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>