### PR TITLE
global: addition of REST api for Block Schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .settings
 .version
 .ropeproject
+.idea/
 Invenio.egg-info
 Makefile.in
 TAGS

--- a/b2share/modules/communities/api.py
+++ b/b2share/modules/communities/api.py
@@ -171,7 +171,7 @@ class Community(object):
         """Update the community's metadata with a json-patch.
 
         Args:
-            patch (str): json-patch which can modify the following fields:
+            patch (dict): json-patch which can modify the following fields:
                 name, description, logo.
 
         Returns:

--- a/b2share/modules/schemas/errors.py
+++ b/b2share/modules/schemas/errors.py
@@ -82,6 +82,42 @@ class BlockSchemaVersionIsReleased(B2ShareSchemasError):
     """Exception raised while trying to modify a released block schema."""
     pass
 
+
+#
+# BLOCK SCHEMA VERSION ERRORS
+#
+
+class InvalidSchemaVersionError(B2ShareSchemasError):
+    """Exception raised when trying to add a version with wrong id."""
+
+    MESSAGE = """Version number is invalid. Provided version number should
+                follow the last existing version number, which currently
+                is {0}."""
+
+    def __init__(self, last_version):
+        """Constructor."""
+        self.last_version = last_version
+        """Error message."""
+        super(InvalidSchemaVersionError, self).__init__(
+            self.MESSAGE.format(last_version)
+        )
+
+
+class SchemaVersionExistsError(B2ShareSchemasError):
+    """Exception raised when trying to add an existing version."""
+
+    MESSAGE = """Version number already exists. Provided version number should
+                follow the last existing version number, which currently
+                is {0}."""
+
+    def __init__(self, last_version):
+        """Constructor."""
+        self.last_version = last_version
+        """Error message."""
+        super(SchemaVersionExistsError, self).__init__(
+            self.MESSAGE.format(last_version)
+        )
+
 #
 # COMMUNITY SCHEMA VERSION ERRORS
 #

--- a/b2share/modules/schemas/models.py
+++ b/b2share/modules/schemas/models.py
@@ -28,6 +28,8 @@ from datetime import datetime
 
 import sqlalchemy as sa
 from invenio_db import db
+from sqlalchemy_utils.models import Timestamp
+from sqlalchemy_utils.models import Timestamp
 from sqlalchemy_utils.types import UUIDType
 
 from b2share.modules.communities.models import Community
@@ -45,11 +47,14 @@ class RootSchemaVersion(db.Model):
     """JSON Schema."""
 
 
-class BlockSchema(db.Model):
+class BlockSchema(db.Model, Timestamp):
     """Represent one of the community's metadata block schema in the database.
 
     Every schema is versioned. Previous versions can always be accessible.
     These versions are represented as BlockSchemaVersion.
+
+    Additionally it contains two columns ``created`` and ``updated``
+    with automatically managed timestamps.
     """
 
     __tablename__ = 'b2share_block_schema'

--- a/b2share/modules/schemas/serializers.py
+++ b/b2share/modules/schemas/serializers.py
@@ -55,6 +55,16 @@ def block_schema_version_json_schema_link(block_schema_version, **kwargs):
 
 
 def block_schema_version_to_dict(block_schema_version):
+    """Serializes block schema version to dict.
+
+    Args:
+        block_schema_version
+            (:class:`b2share.modules.schemas.api:BlockSchemaVersion`):
+            block schema version that will be serialized.
+
+    Returns:
+        dict: serialized BlockSchemaVersion.
+    """
     return dict(
         id=block_schema_version.block_schema.id,
         version=block_schema_version.version,
@@ -64,6 +74,20 @@ def block_schema_version_to_dict(block_schema_version):
 
 def block_schema_version_to_json_serializer(block_schema_version, code=200,
                                             headers=None):
+    """Serializes block schema version to json response.
+
+    Args:
+        block_schema_version
+            (:class:`b2share.modules.schemas.api:BlockSchemaVersion`):
+            block schema version that will be serialized.
+
+        code: http response status.
+
+        headers: additional http response headers.
+
+    Returns:
+        Response: serialized response from BlockSchemaVersion.
+    """
     response = jsonify(block_schema_version_to_dict(block_schema_version))
     response.status_code = code
     if headers is not None:
@@ -80,7 +104,7 @@ def community_schema_self_link(community_schema, **kwargs):
 
         **kwargs: additional parameters given to flask.url_for.
 
-    :Returns:
+    Returns:
         str: link pointing to the given community schema.
     """  # noqa
     return url_for(
@@ -112,6 +136,71 @@ def community_schema_to_json_serializer(community_schema, code=200,
     response = jsonify(community_schema_to_dict(community_schema))
     response.status_code = code
     response.set_etag(str(community_schema.released.utcfromtimestamp(0)))
+    if headers is not None:
+        response.headers.extend(headers)
+    return response
+
+
+def block_schema_to_dict(schema):
+    """Serializes block schema to dict.
+
+    Args:
+        schema: block schema to serialize into dict.
+
+    Returns:
+        dict: dict from BlockSchema.
+     """
+    return dict(
+        schema_id=str(schema.id),
+        name=schema.name
+    )
+
+
+def block_schema_to_json_serializer(schema, code=200, headers=None):
+    """Serializes block schema to json response.
+
+    Args:
+        schema: block schema to serialize into json response.
+        code: http response code.
+        headers: additional http response headers.
+
+    Returns:
+        Response: response from list of BlockSchemas.
+     """
+    response = jsonify(block_schema_to_dict(schema))
+    response.status_code = code
+    if headers is not None:
+        response.headers.extend(headers)
+    return response
+
+
+def schemas_list_to_dict(schemas):
+    """Serializes schemas list to dict.
+
+    Args:
+        schemas: list of BlockSchemas.
+
+    Returns:
+        dict: dict with list of BlockSchema.
+     """
+    return dict(
+        schemas=list(map(block_schema_to_dict, schemas))
+    )
+
+
+def schemas_list_to_json_serializer(schemas, code=200, headers=None):
+    """Serializes schema list to json response.
+
+    Args:
+        schemas: list of block schemas.
+        code: http response code.
+        headers: additional http response headers.
+
+    Returns:
+        Response: response from list of BlockSchemas.
+     """
+    response = jsonify(schemas_list_to_dict(schemas))
+    response.status_code = code
     if headers is not None:
         response.headers.extend(headers)
     return response

--- a/b2share/modules/schemas/views.py
+++ b/b2share/modules/schemas/views.py
@@ -28,15 +28,25 @@ from __future__ import absolute_import
 
 from functools import wraps
 
-from flask import Blueprint, abort
+from flask import Blueprint, abort, request, current_app
 from invenio_rest import ContentNegotiatedMethodView
 from b2share.modules.communities.views import pass_community
+from b2share.modules.schemas.errors import InvalidBlockSchemaError, \
+    InvalidSchemaVersionError, SchemaVersionExistsError
+from jsonpatch import JsonPatchConflict, JsonPatchException, \
+    InvalidJsonPatch
 
 from .api import BlockSchema, CommunitySchema
 from .errors import BlockSchemaDoesNotExistError, \
     CommunitySchemaDoesNotExistError
 from .serializers import block_schema_version_to_json_serializer, \
-    community_schema_to_json_serializer
+    block_schema_to_dict, \
+    community_schema_to_json_serializer, \
+    block_schema_to_json_serializer, schemas_list_to_json_serializer
+from invenio_db import db
+from webargs import fields
+from webargs.flaskparser import use_kwargs
+
 
 blueprint = Blueprint(
     'b2share_schemas',
@@ -46,6 +56,7 @@ blueprint = Blueprint(
 
 def pass_block_schema(f):
     """Decorator retrieving a block schema."""
+
     @wraps(f)
     def inner(self, schema_id, *args, **kwargs):
         try:
@@ -54,19 +65,30 @@ def pass_block_schema(f):
         except BlockSchemaDoesNotExistError:
             abort(404)
         return f(self, block_schema=block_schema, *args, **kwargs)
+
     return inner
 
 
 def pass_block_schema_version(f):
     """Decorator retrieving a block schema version."""
+
     @wraps(f)
     def inner(self, block_schema, schema_version_nb, *args, **kwargs):
         try:
-            block_schema_version = block_schema.versions[schema_version_nb]
+            if schema_version_nb == 'last':
+                block_schema_version = block_schema.versions[
+                                            len(block_schema.versions) - 1
+                                       ]
+            elif schema_version_nb.isdigit():
+                version_nb = int(schema_version_nb)
+                block_schema_version = block_schema.versions[schema_version_nb]
+            else:
+                abort(400)
         except IndexError:
             abort(404)
         return f(self, block_schema=block_schema,
                  block_schema_version=block_schema_version, *args, **kwargs)
+
     return inner
 
 
@@ -79,10 +101,6 @@ class BlockSchemaVersionResource(ContentNegotiatedMethodView):
             serializers={
                 'application/json': block_schema_version_to_json_serializer,
             },
-            default_method_media_type={
-                'GET': 'application/json',
-                'PATCH': 'application/json',
-            },
             default_media_type='application/json',
             **kwargs
         )
@@ -90,11 +108,35 @@ class BlockSchemaVersionResource(ContentNegotiatedMethodView):
     @pass_block_schema
     @pass_block_schema_version
     def get(self, block_schema, block_schema_version):
+        self.check_etag(str(block_schema_version.released))
         return block_schema_version
+
+    def put(self, schema_id, schema_version_nb):
+        """Create a new version of the schema."""
+        block_schema = BlockSchema.get_block_schema(schema_id)
+
+        data = request.get_json()
+        if data is None:
+            return abort(400)
+
+        try:
+            schema = block_schema.create_version(
+                                                data['json_schema'],
+                                                int(schema_version_nb)
+                                                )
+        except InvalidSchemaVersionError as e:
+            abort(400, str(e))
+        except SchemaVersionExistsError as e:
+            abort(409, str(e))
+        return self.make_response(
+            block_schema_version=schema,
+            code=201,
+        )
 
 
 def pass_community_schema(f):
     """Decorator retrieving a community schema."""
+
     @wraps(f)
     def inner(self, community_id, schema_version_nb, *args, **kwargs):
         try:
@@ -114,7 +156,9 @@ def pass_community_schema(f):
         except CommunitySchemaDoesNotExistError:
             abort(404)
         return f(self, community_schema=community_schema, *args, **kwargs)
+
     return inner
+
 
 class CommunitySchemaResource(ContentNegotiatedMethodView):
     view_name = 'community_schema_item'
@@ -124,7 +168,7 @@ class CommunitySchemaResource(ContentNegotiatedMethodView):
         super(CommunitySchemaResource, self).__init__(
             serializers={
                 'application/json':
-                community_schema_to_json_serializer,
+                    community_schema_to_json_serializer,
             },
             default_method_media_type={
                 'GET': 'application/json',
@@ -139,12 +183,123 @@ class CommunitySchemaResource(ContentNegotiatedMethodView):
         return community_schema
 
 
+class BlockSchemaListResource(ContentNegotiatedMethodView):
+    view_name = 'block_schema_list'
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        super(BlockSchemaListResource, self).__init__(
+            method_serializers={
+                'GET': {
+                    'application/json': schemas_list_to_json_serializer,
+                },
+                'POST': {
+                    'application/json': block_schema_to_json_serializer,
+                }
+            },
+            default_media_type='application/json',
+            **kwargs
+        )
+
+    def get(self):
+        """Get a list of all schemas."""
+        community_id = request.args['community_id']
+        schemas = BlockSchema.get_all_block_schemas(community_id=community_id)
+        return self.make_response(
+            schemas=schemas,
+            code=200)
+
+    def post(self):
+        """Create a new schema."""
+        if request.content_type != 'application/json':
+            abort(415)
+        data = request.get_json()
+        if data is None:
+            return abort(400)
+
+        schema = BlockSchema.create_block_schema(**data)
+        return self.make_response(
+            schema=schema,
+            code=201,
+        )
+
+
+class BlockSchemaResource(ContentNegotiatedMethodView):
+    view_name = 'block_schema_item'
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        super(BlockSchemaResource, self).__init__(
+            serializers={
+                'application/json': block_schema_to_json_serializer
+            },
+            default_media_type='application/json',
+            **kwargs
+        )
+
+    def get(self, schema_id):
+        """Get a schema."""
+        schema = BlockSchema.get_block_schema(schema_id)
+        self.check_etag(str(schema.updated))
+
+        return self.make_response(
+            schema=schema,
+            code=200
+        )
+
+    def patch(self, schema_id):
+        """Patch a schema."""
+        data = request.get_json(force=True)
+        if data is None:
+            abort(400)
+
+        block_schema = BlockSchema.get_block_schema(schema_id)
+        self.check_etag(str(block_schema.updated))
+
+        try:
+            if 'application/json' == request.content_type:
+                block_schema.update(data)
+            else:
+                block_schema = block_schema.patch(data)
+            db.session.commit()
+            return self.make_response(
+                schema=block_schema,
+                code=200
+            )
+        except (JsonPatchConflict):
+            abort(409)
+        except (JsonPatchException):
+            abort(400)
+        except InvalidBlockSchemaError:
+            db.session.rollback()
+            abort(400)
+        except Exception as e1:
+            current_app.logger.exception('Failed to patch record.')
+            try:
+                db.session.rollback()
+            except Exception as e2:
+                raise e2 from e1
+            abort(500)
+
+
 blueprint.add_url_rule(
-    '/schemas/<string:schema_id>/versions/<int:schema_version_nb>',
+    '/schemas/<string:schema_id>/versions/<string:schema_version_nb>',
     view_func=BlockSchemaVersionResource
-    .as_view(BlockSchemaVersionResource.view_name))
+        .as_view(BlockSchemaVersionResource.view_name))
+
 
 blueprint.add_url_rule(
     '/communities/<string:community_id>/schemas/<string:schema_version_nb>',
     view_func=CommunitySchemaResource
-    .as_view(CommunitySchemaResource.view_name))
+        .as_view(CommunitySchemaResource.view_name))
+
+
+blueprint.add_url_rule(
+    '/schemas/<string:schema_id>',
+    view_func=BlockSchemaResource
+        .as_view(BlockSchemaResource.view_name))
+
+blueprint.add_url_rule(
+    '/schemas',
+    view_func=BlockSchemaListResource
+        .as_view(BlockSchemaListResource.view_name))

--- a/tests/b2share_unit_tests/schemas/test_schemas_rest.py
+++ b/tests/b2share_unit_tests/schemas/test_schemas_rest.py
@@ -32,8 +32,11 @@ import pytest
 from flask import url_for
 from invenio_db import db
 from mock import patch
-from b2share.modules.schemas.api import CommunitySchema
+from b2share.modules.schemas.api import CommunitySchema, BlockSchema, \
+    BlockSchemaVersion
+from b2share.modules.communities.api import Community
 from b2share_unit_tests.helpers import subtest_self_link
+
 
 def test_valid_get(app, test_communities):
     """Test VALID community get request (GET .../communities/<id>)."""
@@ -42,11 +45,11 @@ def test_valid_get(app, test_communities):
         with app.test_client() as client:
             for version in [0, 1, 'last']:
                 headers = [('Content-Type', 'application/json'),
-                        ('Accept', 'application/json')]
+                           ('Accept', 'application/json')]
                 res = client.get(
                     url_for('b2share_schemas.community_schema_item',
                             community_id=community_id,
-                            schema_version_nb=str(version)),
+                            schema_version_nb=version),
                     headers=headers)
                 assert res.status_code == 200
                 # check that the returned community matches the given data
@@ -68,3 +71,190 @@ def test_valid_get(app, test_communities):
         with app.test_client() as client:
             # check that the returned self link returns the same data
             subtest_self_link(response_data, res.headers, client)
+
+
+def test_create_schema(app, test_communities):
+    """Test creating a new schema."""
+    with app.app_context():
+        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.post(
+                url_for(
+                    'b2share_schemas.block_schema_list'
+                ),
+                data=json.dumps({
+                    'name': 'abc',
+                    'community_id': community_id,
+                }),
+                headers=headers)
+            assert res.status_code == 201
+            response_data = json.loads(res.get_data(as_text=True))
+            assert response_data['name'] == BlockSchema.get_block_schema(
+                                                response_data['schema_id']
+                                            ).name
+            assert str(
+                BlockSchema.get_block_schema(response_data['schema_id'])
+                    .community
+            ) == community_id
+
+
+def test_create_schema_version(app, test_communities):
+    """Test creating a new version of the schema."""
+    with app.app_context():
+        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
+        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+        version_schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "name":"abcd"
+        }
+        all_versions = block_schema.versions
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.put(
+                url_for(
+                    'b2share_schemas.block_schema_versions_item',
+                    schema_id=str(block_schema.id),
+                    schema_version_nb=len(all_versions)
+                ),
+                data=json.dumps({
+                    'json_schema': json_schema
+                }),
+                headers=headers)
+            assert res.status_code == 201
+            response_data = json.loads(res.get_data(as_text=True))
+            assert response_data['json_schema'] == json_schema
+
+
+def test_create_existing_schema_version(app, test_communities):
+    """Test creating an axisting version of the schema."""
+    with app.app_context():
+        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
+        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+        version_schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "name":"abcd"
+        }
+        all_versions = block_schema.versions
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.put(
+                url_for(
+                    'b2share_schemas.block_schema_versions_item',
+                    schema_id=str(block_schema.id),
+                    schema_version_nb=len(all_versions) - 1
+                ),
+                data=json.dumps({
+                    'json_schema': json_schema
+                }),
+                headers=headers)
+            assert res.status_code == 409
+
+
+def test_create_invalid_schema_version(app, test_communities):
+    """Test creating an invalid version of the schema."""
+    with app.app_context():
+        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
+        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.put(
+                url_for(
+                    'b2share_schemas.block_schema_versions_item',
+                    schema_id=str(block_schema.id),
+                    schema_version_nb=5
+                ),
+                data=json.dumps({
+                    'json_schema': json_schema
+                }),
+                headers=headers)
+            assert res.status_code == 400
+
+
+def test_get_schema_version(app, test_communities):
+    """Test getting schema version."""
+    with app.app_context():
+        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
+        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+        schema_version1 = block_schema.create_version(json_schema)
+        schema_version2 = block_schema.create_version(json_schema)
+
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.get(
+                url_for(
+                    'b2share_schemas.block_schema_versions_item',
+                    schema_id=str(block_schema.id),
+                    schema_version_nb=1,
+                ),
+                headers=headers)
+            assert res.status_code == 200
+
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.get(
+                url_for(
+                    'b2share_schemas.block_schema_versions_item',
+                    schema_id=str(block_schema.id),
+                    schema_version_nb='last',
+                ),
+                headers=headers)
+            assert res.status_code == 200
+
+
+def test_get_schemas(app, test_communities):
+    """"Test getting list of given community's schemas."""
+    with app.app_context():
+        community = Community.create_community('name1', 'desc1')
+        community_id = community.id
+        community_2 = Community.create_community('name2', 'desc2')
+        community_id2 = community_2.id
+        block_schema_1 = BlockSchema.create_block_schema(community_id, 'abc')
+        block_schema_2 = BlockSchema.create_block_schema(community_id2, 'abc2')
+        block_schema_3 = BlockSchema.create_block_schema(community_id2, 'abc3')
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.get(
+                url_for(
+                    'b2share_schemas.block_schema_list',
+                    community_id=community_id2
+                ),
+                headers=headers)
+            assert res.status_code == 200
+            response_data = json.loads(res.get_data(as_text=True))
+            assert isinstance(response_data['schemas'], list)
+            assert len(response_data['schemas']) == 2
+            assert response_data['schemas'][0]['name'] == block_schema_2.name
+            assert response_data['schemas'][1]['name'] == block_schema_3.name
+
+
+def test_updating_block_schema(app, test_communities):
+    """Test updating a block schema."""
+    with app.app_context():
+        community = Community.create_community('name1', 'desc1')
+        community_id = community.id
+        block_schema = BlockSchema.create_block_schema(community_id, 'original')
+        with app.test_client() as client:
+            headers = [('Content-Type', 'application/json'),
+                       ('Accept', 'application/json')]
+            res = client.patch(
+                url_for(
+                    'b2share_schemas.block_schema_item',
+                    schema_id=block_schema.id
+                ),
+                data=json.dumps({
+                    'name': 'abc'
+                }),
+                headers=headers)
+            assert res.status_code == 200


### PR DESCRIPTION
* NEW Adds a new:
  - POST - creates new Block Schema
  - PUT - creates new Block Schema Version for Block Schema
  - GET - gets list of schemas

Signed-off-by: PaulinaLach <paulina.malgorzata.lach@cern.ch>