### PR TITLE
global: temporary serialization fix

### DIFF
--- a/b2share/modules/records/serializers/response.py
+++ b/b2share/modules/records/serializers/response.py
@@ -44,8 +44,6 @@ def record_responsify(serializer, mimetype):
     bucket_link_tpl = '{0}; rel="' + RECORD_BUCKET_RELATION_TYPE + '"'
 
     def view(pid, record, code=200, headers=None, links_factory=None):
-
-        serializer.serialize(pid, record, links_factory=links_factory)
         response = current_app.response_class(
             serializer.serialize(pid, record, links_factory=links_factory),
             mimetype=mimetype)
@@ -67,10 +65,16 @@ def record_responsify(serializer, mimetype):
 class JSONSerializer(InvenioJSONSerializer):
     def preprocess_record(self, pid, record, links_factory=None):
         g.record = record
-        return super(JSONSerializer, self).preprocess_record(
-            pid, record, links_factory)
+        try:
+            return super(JSONSerializer, self).preprocess_record(
+                pid, record, links_factory)
+        finally:
+            g.pop('record')
 
     def transform_search_hit(self, pid, record_hit, links_factory=None):
         g.record_hit = record_hit
-        return super(JSONSerializer, self).transform_search_hit(
-            pid, record_hit, links_factory)
+        try:
+            return super(JSONSerializer, self).transform_search_hit(
+                pid, record_hit, links_factory)
+        finally:
+            g.pop('record_hit')

--- a/tests/b2share_functional_tests/test_submission.py
+++ b/tests/b2share_functional_tests/test_submission.py
@@ -215,3 +215,15 @@ def test_deposit(app, test_communities, create_user, login_user,
             search_records = {rec['id'] : rec for rec in
                               record_search_data['hits']['hits']}
             assert search_records == open_access_records
+
+            for recid, record_data in created_records.items():
+                # Test record GET permissions
+                record_get_res = client.get(
+                    url_for('b2share_records_rest.b2share_record_item',
+                            pid_value=recid),
+                    headers=headers)
+
+                if recid in open_access_records.keys():
+                    assert record_get_res.status_code == 200
+                else:
+                    assert record_get_res.status_code == 403


### PR DESCRIPTION
* Temporary fix for the serialization exception happening when
  a record GET follows an /api/records/ search.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>