### PR TITLE
deposit: fix '_files' list creation in record

### DIFF
--- a/b2share/modules/records/indexer.py
+++ b/b2share/modules/records/indexer.py
@@ -38,8 +38,9 @@ def indexer_receiver(sender, json=None, record=None, index=None,
         json['_created'] = pytz.utc.localize(record.created).isoformat()
         json['_updated'] = pytz.utc.localize(record.updated).isoformat()
         json['owners'] = record['_deposit']['owners']
-        json['_internal'] = {
-            'files_bucket_id': str(record.files.bucket.id),
-        }
+        if record.files:
+            json['_internal'] = {
+                'files_bucket_id': str(record.files.bucket.id),
+            }
     except Exception:
         raise


### PR DESCRIPTION
* FIX Fixes '_files' list serialization in indexed records.

* Fixes deposit '_files' creation. This fix is temporary and needs
  to be removed once inveniosoftware/invenio-deposit#107 is fixed.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>