### PR TITLE
API/list/upload files: trailing slash after FILE_BUCKET_ID ends with 404 NOT FOUND, upload requires PUT not POST

### DIFF
--- a/webui/src/docs/templates/rest-api.js
+++ b/webui/src/docs/templates/rest-api.js
@@ -124,13 +124,13 @@ module.exports = function(props) {
 			the file bucket URL. This URL can be found in the information returned when
 			querying a record, in the 'links/files' section of the returned data. </p>
 		<ul>
-			<li><p>URL path: /api/files/FILE_BUCKET_ID</p></li>
-			<li><p>HTTP Method: POST</p></li>
+			<li><p>URL path: /api/files/FILE_BUCKET_ID/FILE_NAME</p></li>
+			<li><p>HTTP Method: PUT</p></li>
 			<li><p>Required input data: the file, sent as direct stream</p></li>
 			<li><p>Required parameters: access_token</p></li>
 			<li><p>Returns: informations about the newly uploaded file</p></li>
 		</ul>
-		<p>Example: <code>curl -i -X POST -d @TestFileToBeUploaded.txt http://example.org/api/files/4f947e84-4bf7-4087-86ea-442938b9c2b4/?access_token=LKR35GP7TF</code></p>
+		<p>Example: <code>curl -i -X PUT -d @TestFileToBeUploaded.txt http://example.org/api/files/4f947e84-4bf7-4087-86ea-442938b9c2b4/TestFileToBeUploaded.txt?access_token=LKR35GP7TF</code></p>
 
 		<h3>List the files uploaded into a record object</h3>
 		<p>List the files uploaded into a record object</p>

--- a/webui/src/docs/templates/rest-api.js
+++ b/webui/src/docs/templates/rest-api.js
@@ -135,12 +135,12 @@ module.exports = function(props) {
 		<h3>List the files uploaded into a record object</h3>
 		<p>List the files uploaded into a record object</p>
 		<ul>
-			<li><p>URL path: /api/files/FILE_BUCKET_ID/</p></li>
+			<li><p>URL path: /api/files/FILE_BUCKET_ID</p></li>
 			<li><p>Http Method: GET</p></li>
 			<li><p>Required parameters: access_token</p></li>
 			<li><p>Returns: information about all the files in the record object</p></li>
 		</ul>
-		<p>Example: <code>curl -i http://example.org/api/files/4f947e84-4bf7-4087-86ea-442938b9c2b4/?access_token=LKR35GP7TF</code></p>
+		<p>Example: <code>curl -i http://example.org/api/files/4f947e84-4bf7-4087-86ea-442938b9c2b4?access_token=LKR35GP7TF</code></p>
 
 		<h3>Updating a draft record</h3>
 		<p>This action updates the draft record with new information.</p>


### PR DESCRIPTION
… FOUND

removing the trailing slash works