### PR TITLE
deployment: nginx conf for files REST API fix

### DIFF
--- a/dockerize/nginx/b2share.conf
+++ b/dockerize/nginx/b2share.conf
@@ -26,15 +26,22 @@ server {
         ssl_protocols           TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers             HIGH:!aNULL:!MD5;
 
-        client_max_body_size 100m;
         client_body_timeout 600s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        location /api/files {
+                proxy_pass http://b2share:5000;
+                proxy_request_buffering off;
+                client_max_body_size 1000g;
+        }
 
         location / {
                 proxy_pass http://b2share:5000;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                client_max_body_size 100m;
         }
 
         error_page 500 502 503 504 /50x.html;


### PR DESCRIPTION
* FIX Fixes Nginx thresholds in configuration for files
  REST API. This enables better support big files upload.
  (relates to #1095)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>