### PR TITLE
change b2drop url

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -237,7 +237,7 @@ CFG_FAIL_ON_MISSING_FILE_PID = False
 
 
 B2DROP_SERVER = {
-    'host': 'b2drop.fz-juelich.de',
+    'host': 'b2drop.eudat.eu',
     'protocol': 'https',
     'path': '/remote.php/webdav/',
 }


### PR DESCRIPTION
b2drop.eudat.eu should be used instead of b2drop.fz-juelich.de