### PR TITLE
Record indexing fix and new draft search

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -67,8 +67,6 @@ B2SHARE_RECORDS_REST_ENDPOINTS = dict(
         pid_fetcher='b2share_record',
         record_class='invenio_records_files.api:Record',
         search_class=B2ShareRecordsSearch,
-        search_index='records',
-        search_type='record',
         record_serializers={
             'application/json': ('b2share.modules.records.serializers'
                                  ':json_v1_response'),
@@ -107,9 +105,6 @@ B2SHARE_DEPOSIT_REST_ENDPOINTS = dict(
         pid_minter='b2share_deposit',
         pid_fetcher='b2share_deposit',
         record_class='b2share.modules.deposit.api:Deposit',
-        search_class='b2share.modules.deposit.search:DepositSearch',
-        search_index='deposits',
-        search_type='deposit',
         max_result_window=10000,
         default_media_type='application/json',
         record_serializers={
@@ -135,6 +130,8 @@ B2SHARE_DEPOSIT_REST_ENDPOINTS = dict(
         delete_permission_factory_imp=DeleteDepositPermission,
     ),
 )
+
+INDEXER_RECORD_TO_INDEX='b2share.modules.records.indexer:record_to_index'
 
 #: Files REST permission factory
 FILES_REST_PERMISSION_FACTORY = \

--- a/b2share/modules/deposit/api.py
+++ b/b2share/modules/deposit/api.py
@@ -56,11 +56,6 @@ class PublicationStates(Enum):
 class Deposit(DepositRecord):
     """B2Share Deposit API."""
 
-    indexer = RecordIndexer(
-        record_to_index=lambda record: ('deposits', 'deposit')
-    )
-    """Deposit indexer."""
-
     published_record_class = Record
     """Record API class used for published records."""
 

--- a/b2share/modules/deposit/mappings/__init__.py
+++ b/b2share/modules/deposit/mappings/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EUDAT B2Share.
+# Copyright (C) 2016 University of Tuebingen, CERN, SurfSara.
+#
+# B2Share is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# B2Share is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with B2Share; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""elasticsearch mappings"""

--- a/b2share/modules/deposit/mappings/deposits/deposits.json
+++ b/b2share/modules/deposit/mappings/deposits/deposits.json
@@ -1,6 +1,6 @@
 {
     "mappings" : {
-      "record" : {
+      "deposit" : {
 		 "_all":{
 			"type":"string",
 			"index":"analyzed",

--- a/b2share/modules/deposit/views.py
+++ b/b2share/modules/deposit/views.py
@@ -183,6 +183,4 @@ class DepositResource(RecordResource):
         """Index the published record if the deposit is published."""
         if g.deposit_action == 'publish':
             _, published_record = record.fetch_published()
-            RecordIndexer(
-                record_to_index=lambda record: ('records', 'record')
-            ).index(published_record)
+            RecordIndexer().index(published_record)

--- a/b2share/modules/records/errors.py
+++ b/b2share/modules/records/errors.py
@@ -52,6 +52,11 @@ class UnknownRecordType(B2ShareRecordsError):
     The two main record types are "published record" and "deposit".
     """
 
+class AnonymousDepositSearch(B2ShareRecordsError):
+    """Error raised when an anonymous user tries to search for drafts."""
+    code = 401
+    description = 'Only authenticated users can search for drafts.'
+
 
 def register_error_handlers(app):
     @app.errorhandler(ValidationError)

--- a/b2share/modules/records/indexer.py
+++ b/b2share/modules/records/indexer.py
@@ -27,6 +27,19 @@ import pytz
 from b2share.modules.access.policies import allow_public_file_metadata
 from invenio_records_files.models import RecordsBuckets
 
+from .utils import is_deposit, is_publication
+
+
+def record_to_index(record):
+    """Route the given record to the right index and document type."""
+    if is_deposit(record.model):
+        return 'deposits-deposits', 'deposit'
+    elif is_publication(record.model):
+        return 'records', 'record'
+    else:
+        raise ValueError('Invalid record. It is neither a deposit'
+                         ' nor a publication')
+
 
 def indexer_receiver(sender, json=None, record=None, index=None,
                      **dummy_kwargs):

--- a/b2share/modules/records/tasks.py
+++ b/b2share/modules/records/tasks.py
@@ -71,8 +71,6 @@ def update_expired_embargos():
             record.commit()
         db.session.commit()
 
-        indexer = RecordIndexer(
-            record_to_index=lambda record: ('records', 'record')
-        )
+        indexer = RecordIndexer()
         indexer.bulk_index(record_ids)
         indexer.process_bulk_queue()

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ install_requires = [
     'invenio-search>=1.0.0a7,<1.1.0',
     'jsonresolver[jsonschema]>=0.2.1',
     'invenio-logging>=1.0.0a3',
+    'invenio-indexer>=1.0.0a7',
     'easywebdav>=1.2.0',
 ]
 
@@ -201,7 +202,8 @@ setup(
             'file_key = b2share.modules.deposit.utils:FileKeyConverter',
         ],
         'invenio_search.mappings':[
-            'records = b2share.modules.records.mappings'
+            'records = b2share.modules.records.mappings',
+            'deposits = b2share.modules.deposit.mappings',
         ],
         'invenio_pidstore.fetchers': [
             'b2share_record'

--- a/tests/b2share_functional_tests/test_search.py
+++ b/tests/b2share_functional_tests/test_search.py
@@ -31,9 +31,11 @@ from b2share.modules.deposit.api import PublicationStates
 from invenio_search import current_search
 from flask import url_for as flask_url_for
 from invenio_db import db
+from b2share_unit_tests.helpers import create_user
 
 
-def test_make_record_with_no_file_and_search(app, test_communities, create_user, login_user, test_records_data):
+def test_make_record_with_no_file_and_search(app, test_communities,
+                                             login_user, test_records_data):
     '''Test for issue https://github.com/EUDAT-B2SHARE/b2share/issues/1073'''
     def url_for(*args, **kwargs):
         with app.app_context():

--- a/tests/b2share_functional_tests/test_submission.py
+++ b/tests/b2share_functional_tests/test_submission.py
@@ -29,6 +29,7 @@ import json
 from io import BytesIO
 
 import pytest
+from b2share_unit_tests.helpers import create_user
 from b2share.modules.deposit.api import PublicationStates
 from invenio_search import current_search
 from flask import url_for as flask_url_for
@@ -38,7 +39,7 @@ from invenio_oauth2server.models import Token
 
 
 @pytest.mark.parametrize('authentication', [('user/password'), ('oauth')])
-def test_deposit(app, test_communities, create_user, login_user,
+def test_deposit(app, test_communities, login_user,
                  test_records_data, authentication):
     """Test record submission with classic login and access token."""
     with app.app_context():

--- a/tests/b2share_functional_tests/test_validation_errors.py
+++ b/tests/b2share_functional_tests/test_validation_errors.py
@@ -47,7 +47,7 @@ def make_record_json():
     record_data = {
         'owner': '',
         'title': 'My Errorneous BBMRI record',
-        'community': '$COMMUNITY_ID[MyTestCommunity]',
+        'community': '$COMMUNITY_ID[MyTestCommunity1]',
         'open_access': True,
         'creator': ['Anonymous'],
         'community_specific': {

--- a/tests/b2share_functional_tests/test_validation_errors.py
+++ b/tests/b2share_functional_tests/test_validation_errors.py
@@ -32,8 +32,8 @@ import pytest
 
 from flask import url_for
 from invenio_db import db
-
 from b2share_demo.helpers import resolve_community_id, resolve_block_schema_id
+from b2share_unit_tests.helpers import create_user
 
 
 json_headers = [('Content-Type', 'application/json'),
@@ -67,7 +67,7 @@ record_list_url = (lambda **kwargs:
                            **kwargs))
 
 
-def test_submission_error(app, test_communities, create_user, login_user):
+def test_submission_error(app, test_communities, login_user):
     with app.app_context():
         # FIXME test permissions
         with app.test_client() as client:

--- a/tests/b2share_unit_tests/communities/test_communities_rest.py
+++ b/tests/b2share_unit_tests/communities/test_communities_rest.py
@@ -32,7 +32,7 @@ import pytest
 from flask import url_for
 from b2share_unit_tests.communities.helpers import community_metadata, \
     community_patch, patched_community_metadata
-from b2share_unit_tests.helpers import subtest_self_link
+from b2share_unit_tests.helpers import subtest_self_link, create_user
 from invenio_db import db
 from mock import patch
 
@@ -50,7 +50,7 @@ community_with_and_without_access_control = pytest.mark.parametrize('app', [({
 
 
 @community_with_and_without_access_control
-def test_valid_create(app, create_user, login_user,
+def test_valid_create(app, login_user,
                       communities_permissions):
     """Test VALID community creation request (POST .../communities/)."""
     with app.app_context():
@@ -99,7 +99,7 @@ def test_valid_create(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_invalid_create(app, create_user, login_user,
+def test_invalid_create(app, login_user,
                         communities_permissions):
     """Test INVALID community creation request (POST .../communities/)."""
     with app.app_context():
@@ -172,7 +172,7 @@ def test_invalid_create(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_valid_get(app, create_user, login_user,
+def test_valid_get(app, login_user,
                    communities_permissions):
     """Test VALID community get request (GET .../communities/<id>)."""
     with app.app_context():
@@ -215,7 +215,7 @@ def test_valid_get(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_invalid_get(app, create_user, login_user,
+def test_invalid_get(app, login_user,
                      communities_permissions):
     """Test INVALID community get request (GET .../communities/<id>)."""
     with app.app_context():
@@ -253,7 +253,7 @@ def test_invalid_get(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_valid_patch(app, create_user, login_user,
+def test_valid_patch(app, login_user,
                      communities_permissions, patch_community_function):
     """Test VALID community patch request (PATCH .../communities/<id>)."""
     with app.app_context():
@@ -293,7 +293,7 @@ def test_valid_patch(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_invalid_patch(app, create_user, login_user,
+def test_invalid_patch(app, login_user,
                        communities_permissions):
     """Test INVALID community patch request (PATCH .../communities/<id>)."""
     with app.app_context():
@@ -361,7 +361,7 @@ def test_invalid_patch(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_valid_put(app, create_user, login_user,
+def test_valid_put(app, login_user,
                    communities_permissions):
     """Test VALID community put request (PUT .../communities/<id>)."""
     with app.app_context():
@@ -407,7 +407,7 @@ def test_valid_put(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_invalid_put(app, create_user, login_user,
+def test_invalid_put(app, login_user,
                      communities_permissions):
     """Test INVALID community put request (PUT .../communities/<id>)."""
     with app.app_context():
@@ -464,7 +464,7 @@ def test_invalid_put(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_valid_delete(app, create_user, login_user,
+def test_valid_delete(app, login_user,
                       communities_permissions):
     """Test VALID community delete request (DELETE .../communities/<id>)."""
     with app.app_context():
@@ -498,7 +498,7 @@ def test_valid_delete(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_invalid_delete(app, create_user, login_user,
+def test_invalid_delete(app, login_user,
                         communities_permissions):
     """Test INVALID community delete request (DELETE .../communities/<id>)."""
     with app.app_context():
@@ -520,7 +520,7 @@ def test_invalid_delete(app, create_user, login_user,
 
 
 @community_with_and_without_access_control
-def test_action_on_deleted(app, create_user, login_user,
+def test_action_on_deleted(app, login_user,
                            communities_permissions):
     """Test getting, deleting and updating a perviously deleted community."""
     with app.app_context():

--- a/tests/b2share_unit_tests/communities/test_communities_rest_permissions.py
+++ b/tests/b2share_unit_tests/communities/test_communities_rest_permissions.py
@@ -32,6 +32,7 @@ from invenio_db import db
 
 from b2share.modules.communities import B2ShareCommunities
 from b2share.modules.communities.models import Community as CommunityModel
+from b2share_unit_tests.helpers import create_user
 
 
 @pytest.mark.parametrize('app', [({
@@ -39,8 +40,7 @@ from b2share.modules.communities.models import Community as CommunityModel
     'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': False}
 })],
     indirect=['app'])
-def test_create_access_control(app, create_user, login_user,
-                               communities_permissions):
+def test_create_access_control(app, login_user, communities_permissions):
     """Test community creation with differnet access rights."""
     with app.app_context():
         allowed_user = create_user('allowed')
@@ -91,7 +91,7 @@ def test_create_access_control(app, create_user, login_user,
     'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
 })],
     indirect=['app'])
-def test_create_unlogged_disabled_access_control(app, create_user, login_user,
+def test_create_unlogged_disabled_access_control(app, login_user,
                                                  communities_permissions):
     """Test community creation with ACL disabled and unlogged user."""
     with app.app_context():
@@ -110,8 +110,7 @@ def test_create_unlogged_disabled_access_control(app, create_user, login_user,
     'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
 })],
     indirect=['app'])
-def test_create_not_allowed_disabled_access_control(app, create_user,
-                                                    login_user,
+def test_create_not_allowed_disabled_access_control(app, login_user,
                                                     communities_permissions):
     """Test community creation with ACL disabled and not allowed user."""
     with app.app_context():

--- a/tests/b2share_unit_tests/deposit/test_deposit_api.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_api.py
@@ -28,29 +28,29 @@ from b2share.modules.deposit.api import Deposit, PublicationStates
 from jsonschema.exceptions import ValidationError
 
 
-def test_deposit_create(app, test_deposits):
+def test_deposit_create(app, draft_deposits):
     """Test deposit creation."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         assert (deposit['publication_state']
                 == PublicationStates.draft.name)
         assert (deposit['_deposit']['status'] == 'draft')
 
 
-def test_deposit_submit(app, test_deposits):
+def test_deposit_submit(app, draft_deposits):
     """Test deposit submission."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         deposit.submit()
         assert (deposit['publication_state']
                 == PublicationStates.submitted.name)
         assert (deposit['_deposit']['status'] == 'draft')
 
 
-def test_deposit_update_and_submit(app, test_deposits):
+def test_deposit_update_and_submit(app, draft_deposits):
     """Test deposit submission by updating the "publication_state" field."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         deposit.update({'publication_state':
                         PublicationStates.submitted.name})
         deposit.commit()
@@ -59,10 +59,10 @@ def test_deposit_update_and_submit(app, test_deposits):
         assert (deposit['_deposit']['status'] == 'draft')
 
 
-def test_deposit_publish(app, test_deposits):
+def test_deposit_publish(app, draft_deposits):
     """Test deposit submission by updating the "publication_state" field."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         deposit.submit()
         deposit.publish()
         assert (deposit['publication_state']
@@ -70,10 +70,10 @@ def test_deposit_publish(app, test_deposits):
         assert (deposit['_deposit']['status'] == 'published')
 
 
-def test_deposit_update_and_publish(app, test_deposits):
+def test_deposit_update_and_publish(app, draft_deposits):
     """Test deposit submission by updating the "publication_state" field."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         deposit.submit()
         deposit.update({'publication_state':
                         PublicationStates.published.name})
@@ -83,10 +83,10 @@ def test_deposit_update_and_publish(app, test_deposits):
         assert (deposit['_deposit']['status'] == 'published')
 
 
-def test_deposit_update_unknown_publication_state(app, test_deposits):
+def test_deposit_update_unknown_publication_state(app, draft_deposits):
     """Test deposit submission by updating the "publication_state" field."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         deposit.update({'publication_state':
                         'invalid_state'})
         with pytest.raises(ValidationError):

--- a/tests/b2share_unit_tests/deposit/test_deposit_rest.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_rest.py
@@ -26,14 +26,16 @@
 import json
 
 import pytest
+from invenio_search import current_search_client
 from flask import url_for
 from b2share.modules.deposit.api import PublicationStates, Deposit
 from copy import deepcopy
 from b2share_unit_tests.helpers import (
     subtest_self_link, create_deposit, generate_record_data, url_for_file,
     subtest_file_bucket_content, subtest_file_bucket_permissions,
-    build_expected_metadata, create_user,
+    build_expected_metadata, create_user, create_role,
 )
+from invenio_access.models import ActionUsers, ActionRoles
 from b2share.modules.records.providers import RecordUUIDProvider
 from six import BytesIO
 
@@ -78,11 +80,11 @@ def test_deposit_create(app, test_records_data, test_users, login_user):
                                   client)
 
 
-def test_deposit_submit(app, test_records_data, test_deposits, test_users,
+def test_deposit_submit(app, test_records_data, draft_deposits, test_users,
                         login_user):
     """Test record draft submit with HTTP PATCH."""
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         record_data = test_records_data[0]
         with app.test_client() as client:
             user = test_users['deposits_creator']
@@ -108,7 +110,7 @@ def test_deposit_submit(app, test_records_data, test_deposits, test_users,
                 draft=True,
             )
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         with app.test_client() as client:
             user = test_users['deposits_creator']
             login_user(user, client)
@@ -122,12 +124,12 @@ def test_deposit_submit(app, test_records_data, test_deposits, test_users,
                               client)
 
 
-def test_deposit_publish(app, test_records_data, test_deposits, test_users,
+def test_deposit_publish(app, test_records_data, draft_deposits, test_users,
                          login_user):
     """Test record draft publication with HTTP PATCH."""
     record_data = test_records_data[0]
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         with app.test_client() as client:
             user = test_users['deposits_creator']
             login_user(user, client)
@@ -153,7 +155,7 @@ def test_deposit_publish(app, test_records_data, test_deposits, test_users,
             )
 
     with app.app_context():
-        deposit = Deposit.get_record(test_deposits[0])
+        deposit = Deposit.get_record(draft_deposits[0].id)
         with app.test_client() as client:
             user = test_users['deposits_creator']
             login_user(user, client)
@@ -301,6 +303,76 @@ def test_deposit_read_permissions(app, test_records_data,
         test_get(deposit, 200, admin)
         deposit.publish()
         test_get(deposit, 200, admin)
+
+
+def test_deposit_search_permissions(app, draft_deposits, submitted_deposits,
+                                    test_users, login_user, test_communities):
+    """Test deposit search permissions."""
+    with app.app_context():
+        # flush the indices so that indexed deposits are searchable
+        current_search_client.indices.flush('*')
+
+        admin = test_users['admin']
+        creator = test_users['deposits_creator']
+        non_creator = create_user('non-creator')
+
+        allowed_role = create_role(
+            'allowed_role',
+            permissions=[('read-deposit-submitted', None),]
+        )
+        user_allowed_by_role = create_user('user-allowed-by-role',
+                                           roles=[allowed_role])
+        user_allowed_by_permission = create_user(
+            'user-allowed-by-permission',
+            permissions=[('read-deposit-submitted',
+                          str(test_communities['MyTestCommunity2']))]
+        )
+
+        search_deposits_url = url_for(
+            'b2share_records_rest.b2share_record_list', drafts=1, size=100)
+        headers = [('Content-Type', 'application/json'),
+                ('Accept', 'application/json')]
+
+        def test_search(status, expected_deposits, user=None):
+            with app.test_client() as client:
+                if user is not None:
+                    login_user(user, client)
+                deposit_search_res = client.get(
+                    search_deposits_url,
+                    headers=headers)
+                assert deposit_search_res.status_code == status
+                # test the response data only when the user is allowed to
+                # search for deposits
+                if status != 200:
+                    return
+                deposit_search_data = json.loads(
+                    deposit_search_res.get_data(as_text=True))
+
+                assert deposit_search_data['hits']['total'] == \
+                    len(expected_deposits)
+
+                deposit_pids = [hit['id'] for hit
+                            in deposit_search_data['hits']['hits']]
+                expected_deposit_pids = [dep.id.hex for dep
+                                         in expected_deposits]
+                deposit_pids.sort()
+                expected_deposit_pids.sort()
+                assert deposit_pids == expected_deposit_pids
+
+        test_search(200, draft_deposits + submitted_deposits, creator)
+        test_search(200, draft_deposits + submitted_deposits, admin)
+        test_search(401, [], None)
+        test_search(200, [], non_creator)
+
+        test_search(200, submitted_deposits, user_allowed_by_role)
+
+        # search for submitted records
+        community2_deposits = [dep for dep in submitted_deposits
+                                if dep.data['community'] ==
+                                str(test_communities['MyTestCommunity2'])]
+        test_search(200,
+                    community2_deposits,
+                    user_allowed_by_permission)
 
 
 def test_deposit_delete_permissions(app, test_records_data,

--- a/tests/b2share_unit_tests/helpers.py
+++ b/tests/b2share_unit_tests/helpers.py
@@ -26,7 +26,9 @@
 import json
 from copy import deepcopy
 from contextlib import contextmanager
+from collections import namedtuple
 
+from flask_security.utils import encrypt_password
 from b2share.modules.records.links import url_for_bucket
 from flask import current_app, url_for
 from six import string_types, BytesIO
@@ -35,6 +37,7 @@ from invenio_accounts.models import User
 from b2share.modules.deposit.api import Deposit
 from b2share_demo.helpers import resolve_community_id, resolve_block_schema_id
 from invenio_indexer.api import RecordIndexer
+from invenio_db import db
 
 
 def url_for_file(bucket_id, key):
@@ -124,6 +127,32 @@ def subtest_file_bucket_permissions(client, bucket, access_level=None,
                               unauthorized_code)
     elif access_level == 'write':
         test_files_permission(200, 200, 204)
+
+
+UserInfo = namedtuple('UserInfo', ['id', 'email', 'password'])
+"""Generated user information."""
+
+
+def create_user(name):
+    """Create a user.
+
+    Returns:
+        (UserInfo) created user's information.
+    """
+
+    users_password = '123456'
+    accounts = current_app.extensions['invenio-accounts']
+    security = current_app.extensions['security']
+
+    email = '{}@example.org'.format(name)
+    with db.session.begin_nested():
+        user = accounts.datastore.create_user(
+            email=email,
+            password=encrypt_password(users_password),
+            active=True,
+        )
+        db.session.add(user)
+    return UserInfo(email=email, password=users_password, id=user.id)
 
 
 def build_expected_metadata(record_data, state, owners=None, draft=False):

--- a/tests/b2share_unit_tests/records/test_records_index.py
+++ b/tests/b2share_unit_tests/records/test_records_index.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of EUDAT B2Share.
+# Copyright (C) 2016 CERN.
+#
+# B2Share is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# B2Share is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with B2Share; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test record indexing."""
+
+import json
+
+from flask import url_for
+from click.testing import CliRunner
+from invenio_search import current_search_client, current_search
+from invenio_indexer import cli
+from invenio_indexer.tasks import process_bulk_queue
+from invenio_indexer.api import RecordIndexer
+
+
+def test_record_indexing(app, test_users, test_records, script_info,
+                         login_user):
+    """Test record indexing."""
+
+    creator = test_users['deposits_creator']
+
+    with app.app_context():
+        current_search_client.indices.flush('*')
+        # delete all elasticsearch indices
+        res = current_search_client.search(index="records",
+                                           body={"query": {"match_all": {}}})
+
+    with app.app_context():
+        # delete all elasticsearch indices and recreate them
+        for deleted in current_search.delete(ignore=[404]):
+            pass
+        for created in current_search.create(None):
+            pass
+
+        runner = CliRunner()
+        # Initialize queue
+        res = runner.invoke(cli.queue, ['init', 'purge'],
+                            obj=script_info)
+        assert 0 == res.exit_code
+        # schedule a reindex task
+        res = runner.invoke(cli.reindex, ['--yes-i-know'], obj=script_info)
+        assert 0 == res.exit_code
+        # execute scheduled tasks synchronously
+        process_bulk_queue.delay()
+        # flush the indices so that indexed records are searchable
+        current_search_client.indices.flush('*')
+
+        search_url = url_for('b2share_records_rest.b2share_record_list')
+        search_deposits_url = url_for('b2share_records_rest.b2share_record_list',
+                                      drafts=1)
+
+    headers = [('Content-Type', 'application/json'),
+               ('Accept', 'application/json')]
+
+
+    with app.app_context():
+        # delete all elasticsearch indices
+        res = current_search_client.search(index="records",
+                                           body={"query": {"match_all": {}}})
+        pass
+
+    # search for published records
+    with app.test_client() as client:
+        record_search_res = client.get(
+            search_url,
+            data='',
+            headers=headers)
+        assert record_search_res.status_code == 200
+        record_search_data = json.loads(
+            record_search_res.get_data(as_text=True))
+        assert record_search_data['hits']['total'] == len(test_records)
+        record_pids = [hit['id'] for hit
+                       in record_search_data['hits']['hits']]
+        expected_record_pids = [str(rec[1]) for rec in test_records]
+        record_pids.sort()
+        expected_record_pids.sort()
+        assert record_pids == expected_record_pids
+
+    # search for draft records
+    with app.test_client() as client:
+        login_user(creator, client)
+        deposit_search_res = client.get(
+            search_deposits_url,
+            data='',
+            headers=headers)
+        assert deposit_search_res.status_code == 200
+        deposit_search_data = json.loads(
+            deposit_search_res.get_data(as_text=True))
+        assert deposit_search_data['hits']['total'] == len(test_records)
+        deposit_pids = [hit['id'] for hit
+                       in deposit_search_data['hits']['hits']]
+        expected_deposit_pids = [rec[0].hex for rec in test_records]
+        deposit_pids.sort()
+        expected_deposit_pids.sort()
+        assert deposit_pids == expected_deposit_pids

--- a/tests/b2share_unit_tests/records/test_records_rest.py
+++ b/tests/b2share_unit_tests/records/test_records_rest.py
@@ -30,7 +30,7 @@ from flask import url_for
 from b2share_unit_tests.helpers import (
     create_record, generate_record_data, url_for_file,
     subtest_file_bucket_content, subtest_file_bucket_permissions,
-    build_expected_metadata, subtest_self_link,
+    build_expected_metadata, subtest_self_link, create_user,
 )
 from b2share.modules.deposit.api import PublicationStates
 from b2share.modules.records.links import url_for_bucket
@@ -39,13 +39,14 @@ from jsonpatch import apply_patch
 
 
 def test_record_content(app, test_communities,
-                        create_user, login_user, admin):
+                        login_user, test_users):
     """Test record read with REST API."""
 
     uploaded_files = {
         'myfile1.dat': b'contents1',
         'myfile2.dat': b'contents2'
     }
+    admin = test_users['admin']
 
     with app.app_context():
         creator = create_user('creator')
@@ -91,13 +92,14 @@ def test_record_content(app, test_communities,
 
 
 def test_record_read_permissions(app, test_communities,
-                                 create_user, login_user, admin):
+                                 login_user, test_users):
     """Test record read with REST API."""
 
     uploaded_files = {
         'myfile1.dat': b'contents1',
         'myfile2.dat': b'contents2'
     }
+    admin = test_users['admin']
 
     with app.app_context():
         creator = create_user('creator')
@@ -159,9 +161,10 @@ def test_record_read_permissions(app, test_communities,
 
 
 def test_modify_metadata_published_record_permissions(app, test_communities,
-                                                      create_user, login_user,
-                                                      admin):
+                                                      login_user, test_users):
     """Test record's metadata modification with REST API."""
+
+    admin = test_users['admin']
     with app.app_context():
         creator = create_user('creator')
         non_creator = create_user('non-creator')

--- a/tests/b2share_unit_tests/records/test_records_tasks.py
+++ b/tests/b2share_unit_tests/records/test_records_tasks.py
@@ -26,7 +26,8 @@
 from datetime import datetime, timedelta
 
 from b2share_unit_tests.helpers import (
-    create_record, generate_record_data, subtest_file_bucket_permissions
+    create_record, generate_record_data, subtest_file_bucket_permissions,
+    create_user,
 )
 from b2share.modules.records.tasks import update_expired_embargos
 # from invenio_records_files.api import Record
@@ -36,8 +37,7 @@ from invenio_files_rest.models import Bucket
 from invenio_records_files.api import Record
 
 
-def test_update_expired_embargo(app, test_communities, login_user,
-                                create_user):
+def test_update_expired_embargo(app, test_communities, login_user):
     """Test record embargo update."""
 
     uploaded_files = {

--- a/tests/b2share_unit_tests/records/test_records_utils.py
+++ b/tests/b2share_unit_tests/records/test_records_utils.py
@@ -25,9 +25,9 @@
 
 from b2share_unit_tests.helpers import create_deposit
 from b2share.modules.records.utils import is_publication, is_deposit
+from b2share_unit_tests.helpers import create_user
 
-
-def test_records_type_helpers(app, test_records_data, create_user):
+def test_records_type_helpers(app, test_records_data):
     """Test record util functions retrieving the record type."""
     with app.app_context():
         creator = create_user('creator')

--- a/tests/b2share_unit_tests/schemas/test_schemas_rest.py
+++ b/tests/b2share_unit_tests/schemas/test_schemas_rest.py
@@ -41,7 +41,7 @@ from b2share_unit_tests.helpers import subtest_self_link
 def test_valid_get(app, test_communities):
     """Test VALID community get request (GET .../communities/<id>)."""
     with app.app_context():
-        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        community_id = str(test_communities['MyTestCommunity1'])
         with app.test_client() as client:
             for version in [0, 1, 'last']:
                 headers = [('Content-Type', 'application/json'),
@@ -76,7 +76,7 @@ def test_valid_get(app, test_communities):
 def test_create_schema(app, test_communities):
     """Test creating a new schema."""
     with app.app_context():
-        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        community_id = str(test_communities['MyTestCommunity1'])
         with app.test_client() as client:
             headers = [('Content-Type', 'application/json'),
                        ('Accept', 'application/json')]
@@ -103,7 +103,7 @@ def test_create_schema(app, test_communities):
 def test_create_schema_version(app, test_communities):
     """Test creating a new version of the schema."""
     with app.app_context():
-        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        community_id = str(test_communities['MyTestCommunity1'])
         json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
         version_schema = {
@@ -132,7 +132,7 @@ def test_create_schema_version(app, test_communities):
 def test_create_existing_schema_version(app, test_communities):
     """Test creating an axisting version of the schema."""
     with app.app_context():
-        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        community_id = str(test_communities['MyTestCommunity1'])
         json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
         version_schema = {
@@ -159,7 +159,7 @@ def test_create_existing_schema_version(app, test_communities):
 def test_create_invalid_schema_version(app, test_communities):
     """Test creating an invalid version of the schema."""
     with app.app_context():
-        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        community_id = str(test_communities['MyTestCommunity1'])
         json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
         with app.test_client() as client:
@@ -181,7 +181,7 @@ def test_create_invalid_schema_version(app, test_communities):
 def test_get_schema_version(app, test_communities):
     """Test getting schema version."""
     with app.app_context():
-        community_id = '2b884138-898f-4651-bf82-34dea0e0e83f'
+        community_id = str(test_communities['MyTestCommunity1'])
         json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
         schema_version1 = block_schema.create_version(json_schema)

--- a/tests/data/communities/my_test_community1.json
+++ b/tests/data/communities/my_test_community1.json
@@ -1,7 +1,7 @@
 {
-    "name": "MyTestCommunity",
-    "description": "Test community.",
-    "id": "2b884138-898f-4651-bf82-34dea0e0e83f",
+    "name": "MyTestCommunity1",
+    "description": "Test community 1.",
+    "id": "cccccccc-1111-1111-1111-111111111111",
     "logo": "",
     "community_schemas": [
         {
@@ -35,7 +35,7 @@
     ],
     "block_schemas": {
         "MyTestSchema": {
-            "id": "38e12922-a361-49a1-853b-92a6863bfa58",
+            "id": "bbbbbbbb-1111-1111-1111-111111111111",
             "versions": [
                 {
                     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/tests/data/communities/my_test_community2.json
+++ b/tests/data/communities/my_test_community2.json
@@ -1,0 +1,36 @@
+{
+    "name": "MyTestCommunity2",
+    "description": "Test community.",
+    "id": "cccccccc-2222-2222-2222-222222222222",
+    "logo": "",
+    "community_schemas": [
+        {
+            "root_schema_version": 0,
+            "json_schema": {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "$BLOCK_SCHEMA_ID[MyTestSchema]": {
+                        "$ref":
+                        "$BLOCK_SCHEMA_VERSION_URL[$BLOCK_SCHEMA_ID[MyTestSchema]::1]#/json_schema"
+                    }
+                },
+                "additionalProperties": false
+            }
+        }, {
+            "root_schema_version": 0,
+            "json_schema": {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "$BLOCK_SCHEMA_ID[MyTestSchema]": {
+                        "$ref":
+                        "$BLOCK_SCHEMA_VERSION_URL[$BLOCK_SCHEMA_ID[MyTestSchema]::2]#/json_schema"
+                    }
+                },
+                "additionalProperties": false
+            }
+        }],
+    "block_schemas": {
+    }
+}


### PR DESCRIPTION
* Simplifies test fixtures.

* FIX Fixes indexing by providing a default RecordIndexer
  separating drafts and published records. (closes #1134)

* NEW Enables draft record search. (addresses #1039)