### PR TITLE
global: elasticsearch lib version fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 install_requires = [
+    'elasticsearch<3.0.0,>=2.0.0',
     'datacite>=0.2.1',
     'dcxml>=0.1.0',
     'dojson>=1.2.1',


### PR DESCRIPTION
* FIX Fixes tests and deployment by pinning elasticsearch
  library version. (closes #1164)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>