### PR TITLE
Fix file upload documentation

### DIFF
--- a/webui/src/docs/rest-api.jsx
+++ b/webui/src/docs/rest-api.jsx
@@ -435,7 +435,7 @@ module.exports = function() {
             <li><p>Returns: informations about the newly uploaded file</p></li>
         </ul>
         <Example>
-            curl -X PUT -d @TestFileToBeUploaded.txt https://$HOSTNAME/api/files/$FILE_BUCKET_ID/TestFileToBeUploaded.txt?access_token=$ACCESS_TOKEN
+            curl -X PUT -H 'Accept:application/json' -H 'Content-Type:application/octet-stream' -d @TestFileToBeUploaded.txt https://$HOSTNAME/api/files/$FILE_BUCKET_ID/TestFileToBeUploaded.txt?access_token=$ACCESS_TOKEN
         </Example>
 
         <h3>List the files uploaded into a record object</h3>


### PR DESCRIPTION
The content-type seems to be extremely important and when missing will cause the request failure. It's important to document this.