### PR TITLE
global: oauth and docker fixes

### DIFF
--- a/dockerize/Dockerfile
+++ b/dockerize/Dockerfile
@@ -96,4 +96,4 @@ WORKDIR /eudat
 ADD . b2share
 
 WORKDIR /eudat/b2share
-CMD ["/usr/bin/supervisord"]
+CMD ["/eudat/b2share.sh"]

--- a/dockerize/b2share.sh
+++ b/dockerize/b2share.sh
@@ -22,4 +22,4 @@ if [ "${LOAD_DEMO_CONFIG}" = "1" ]; then
     export SSL_CERT_FILE="/eudat/b2share/staging_b2access.pem"
 fi
 
-/usr/bin/b2share run -h 0.0.0.0
+/usr/bin/supervisord

--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -11,13 +11,13 @@ services:
     #     volumes:
     #         - /data/db:/var/lib/mysql
     elasticsearch:
-        image: elasticsearch
+        image: elasticsearch:2.2
         ports:
             - "9200:9200"
             - "9300:9300"
 
     redis:
-        image: redis
+        image: redis:3.2
         ports:
             - "6379:6379"
 
@@ -46,7 +46,7 @@ services:
         links:
             - b2share
     mq:
-        image: rabbitmq:3-management
+        image: rabbitmq:3.6-management
         restart: "always"
         ports:
             - "15672:15672"

--- a/dockerize/nginx/Dockerfile
+++ b/dockerize/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:1.11
 EXPOSE 80 443
 
 RUN rm /etc/nginx/conf.d/*.conf


### PR DESCRIPTION
* FIX Fixes OAuth authentication. (closes #1193)

* Improves oauth authentication by saving B2Access's
  persistent identifier.

* FIX Fixes docker container is not initialization. (closes #1194)

* FIX Pins service versions in docker-compose scripts.
  (closes #1195)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>