### PR TITLE
test: travis "current" build marked as optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: REQUIREMENTS=current REXTRAS=all ES_VERSION=2.3.3
     - env: REQUIREMENTS=devel REXTRAS=all ES_VERSION=2.3.3
 
 python:


### PR DESCRIPTION
This is a temporary measure as we are updating production and "current" build fails because of Invenio changes.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>