### PR TITLE
global: pid_types renaming

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -62,10 +62,10 @@ B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED = False
 RECORDS_REST_ENDPOINTS={}
 #: Records REST API endpoints.
 B2SHARE_RECORDS_REST_ENDPOINTS = dict(
-    b2share_record=dict(
-        pid_type='b2share_record',
-        pid_minter='b2share_deposit',
-        pid_fetcher='b2share_record',
+    b2rec=dict(
+        pid_type='b2rec',
+        pid_minter='b2dep',
+        pid_fetcher='b2rec',
         record_class='invenio_records_files.api:Record',
         search_class=B2ShareRecordsSearch,
         record_serializers={
@@ -88,7 +88,7 @@ B2SHARE_RECORDS_REST_ENDPOINTS = dict(
         },
         default_media_type='application/json',
         list_route='/records/',
-        item_route='/records/<pid(b2share_record,record_class="invenio_records_files.api:Record"):pid_value>',
+        item_route='/records/<pid(b2rec,record_class="invenio_records_files.api:Record"):pid_value>',
         create_permission_factory_imp=CreateDepositPermission,
         read_permission_factory_imp=allow_all,
         update_permission_factory_imp=UpdateRecordPermission,
@@ -99,13 +99,13 @@ B2SHARE_RECORDS_REST_ENDPOINTS = dict(
 
 DEPOSIT_REST_ENDPOINTS={}
 #: REST API configuration.
-DEPOSIT_PID = 'pid(b2share_deposit,record_class="b2share.modules.deposit.api:Deposit")'
-DEPOSIT_PID_MINTER='b2share_record'
+DEPOSIT_PID = 'pid(b2dep,record_class="b2share.modules.deposit.api:Deposit")'
+DEPOSIT_PID_MINTER='b2rec'
 B2SHARE_DEPOSIT_REST_ENDPOINTS = dict(
-    b2share_deposit=dict(
-        pid_type='b2share_deposit',
-        pid_minter='b2share_deposit',
-        pid_fetcher='b2share_deposit',
+    b2dep=dict(
+        pid_type='b2dep',
+        pid_minter='b2dep',
+        pid_fetcher='b2dep',
         record_class='b2share.modules.deposit.api:Deposit',
         max_result_window=10000,
         default_media_type='application/json',
@@ -187,7 +187,7 @@ ACCOUNTS_REGISTER_BLUEPRINT = True
 
 # OAI-PMH
 OAISERVER_RECORD_INDEX = 'records'
-OAISERVER_ID_PREFIX = 'oai:b2share.eudat.eu:b2share_record/'
+OAISERVER_ID_PREFIX = 'oai:b2share.eudat.eu:b2rec/'
 OAISERVER_PAGE_SIZE = 25
 OAISERVER_ADMIN_EMAILS = [SUPPORT_EMAIL]
 OAISERVER_REGISTER_RECORD_SIGNALS = False

--- a/b2share/modules/deposit/providers.py
+++ b/b2share/modules/deposit/providers.py
@@ -33,7 +33,7 @@ from invenio_pidstore.models import PIDStatus
 class DepositUUIDProvider(BaseProvider):
     """Deposit identifier provider."""
 
-    pid_type = 'b2share_deposit'
+    pid_type = 'b2dep'
     """Type of persistent identifier."""
 
     pid_provider = None

--- a/b2share/modules/records/minters.py
+++ b/b2share/modules/records/minters.py
@@ -146,7 +146,7 @@ def b2share_doi_minter(record_uuid, data):
 
 
 def make_record_url(recid):
-    endpoint = 'b2share_records_rest.b2share_record_item'
+    endpoint = 'b2share_records_rest.b2rec_item'
     url = url_for(endpoint, pid_value=recid, _external=True)
     url = url.replace('/api/records/', '/records/')
     return url

--- a/b2share/modules/records/providers.py
+++ b/b2share/modules/records/providers.py
@@ -35,7 +35,7 @@ class RecordUUIDProvider(BaseProvider):
     The deposit PID value has to be provided as it is used for the record PID.
     """
 
-    pid_type = 'b2share_record'
+    pid_type = 'b2rec'
     """Type of persistent identifier."""
 
     pid_provider = None

--- a/b2share/modules/records/serializers/schemas/dc.py
+++ b/b2share/modules/records/serializers/schemas/dc.py
@@ -36,7 +36,7 @@ def md_getter_list(attribute):
     return lambda record: [record['metadata'].get(attribute)]
 
 def record_url(pid_value):
-    return url_for('b2share_records_rest.b2share_record_item',
+    return url_for('b2share_records_rest.b2rec_item',
         pid_value=pid_value, _external=True)
 
 class RecordSchemaDublinCoreV1(Schema):

--- a/setup.py
+++ b/setup.py
@@ -199,9 +199,9 @@ setup(
             'b2share_schemas = b2share.modules.schemas.jsonresolver',
         ],
         'invenio_pidstore.minters': [
-            'b2share_record'
+            'b2rec'
             '= b2share.modules.records.minters:b2share_record_uuid_minter',
-            'b2share_deposit'
+            'b2dep'
             '= b2share.modules.deposit.minters:b2share_deposit_uuid_minter',
         ],
         'invenio_base.api_converters': [
@@ -212,9 +212,9 @@ setup(
             'deposits = b2share.modules.deposit.mappings',
         ],
         'invenio_pidstore.fetchers': [
-            'b2share_record'
+            'b2rec'
             '= b2share.modules.records.fetchers:b2share_record_uuid_fetcher',
-            'b2share_deposit'
+            'b2dep'
             '= b2share.modules.deposit.fetchers:b2share_deposit_uuid_fetcher',
         ],
         'invenio_celery.tasks': [

--- a/tests/b2share_functional_tests/test_search.py
+++ b/tests/b2share_functional_tests/test_search.py
@@ -62,7 +62,7 @@ def test_make_record_with_no_file_and_search(app, test_communities,
 
         # create record without files
         draft_create_res = client.post(
-            url_for('b2share_records_rest.b2share_record_list'),
+            url_for('b2share_records_rest.b2rec_list'),
             data=json.dumps(record_data), headers=headers)
         assert draft_create_res.status_code == 201
         draft_create_data = json.loads(
@@ -70,7 +70,7 @@ def test_make_record_with_no_file_and_search(app, test_communities,
 
         # submit the record
         draft_submit_res = client.patch(
-            url_for('b2share_deposit_rest.b2share_deposit_item',
+            url_for('b2share_deposit_rest.b2dep_item',
                     pid_value=draft_create_data['id']),
             data=json.dumps([{
                 "op": "replace", "path": "/publication_state",
@@ -83,7 +83,7 @@ def test_make_record_with_no_file_and_search(app, test_communities,
         login_user(com_admin, client)
         # publish record
         draft_publish_res = client.patch(
-            url_for('b2share_deposit_rest.b2share_deposit_item',
+            url_for('b2share_deposit_rest.b2dep_item',
                     pid_value=draft_create_data['id']),
             data=json.dumps([{
                 "op": "replace", "path": "/publication_state",
@@ -96,7 +96,7 @@ def test_make_record_with_no_file_and_search(app, test_communities,
 
         # get record
         record_get_res = client.get(
-            url_for('b2share_records_rest.b2share_record_item',
+            url_for('b2share_records_rest.b2rec_item',
                     pid_value=draft_publish_data['id']),
             headers=headers)
         assert record_get_res.status_code == 200
@@ -111,7 +111,7 @@ def test_make_record_with_no_file_and_search(app, test_communities,
     with app.test_client() as client:
         # test search, for crashes
         record_search_res = client.get(
-            url_for('b2share_records_rest.b2share_record_list'),
+            url_for('b2share_records_rest.b2rec_list'),
             data='',
             headers=headers)
         assert record_search_res.status_code == 200

--- a/tests/b2share_functional_tests/test_submission.py
+++ b/tests/b2share_functional_tests/test_submission.py
@@ -127,7 +127,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
             login_user(allowed_user, client)
             record_list_url = (
                 lambda **kwargs:
-                url_for('b2share_records_rest.b2share_record_list',
+                url_for('b2share_records_rest.b2rec_list',
                         **kwargs))
             draft_create_res = client.post(record_list_url(),
                                             data=json.dumps(record_data),
@@ -166,7 +166,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
             headers = [('Content-Type', 'application/json-patch+json'),
                        ('Accept', 'application/json')] + allowed_headers
             draft_patch_res = client.patch(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=draft_create_data['id']),
                 data=json.dumps([{"op": "replace", "path": "/titles", "value":
                                     [{"title":"first-patched-title"}]}]),
@@ -177,7 +177,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
 
             # Test draft GET
             draft_unpublished_get_res = client.get(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=draft_create_data['id']),
                 headers=headers)
             assert draft_unpublished_get_res.status_code == 200
@@ -186,7 +186,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
 
             # test draft submit
             draft_submit_res = client.patch(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=draft_create_data['id']),
                 data=json.dumps([{
                     "op": "replace", "path": "/publication_state",
@@ -199,7 +199,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
             login_user(com_admin, client)
             # test draft publish
             draft_publish_res = client.patch(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=draft_create_data['id']),
                 data=json.dumps([{
                     "op": "replace", "path": "/publication_state",
@@ -213,7 +213,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
 
             # Test draft GET
             draft_published_get_res = client.get(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=draft_create_data['id']),
                 headers=headers)
             assert draft_published_get_res.status_code == 200
@@ -222,7 +222,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
 
             # Test record GET
             record_get_res = client.get(
-                url_for('b2share_records_rest.b2share_record_item',
+                url_for('b2share_records_rest.b2rec_item',
                         pid_value=draft_publish_data['id']),
                 headers=headers)
             assert record_get_res.status_code == 200
@@ -245,7 +245,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
 
         # test search  records
         record_search_res = client.get(
-            url_for('b2share_records_rest.b2share_record_list'),
+            url_for('b2share_records_rest.b2rec_list'),
             data='',
             headers=headers)
         assert record_search_res.status_code == 200
@@ -265,7 +265,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
         login_user(other_user, client)
         # test search
         record_search_res = client.get(
-            url_for('b2share_records_rest.b2share_record_list'),
+            url_for('b2share_records_rest.b2rec_list'),
             data='',
             headers=headers)
         assert record_search_res.status_code == 200
@@ -283,7 +283,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
         for recid, record_data in created_records.items():
             # Test record GET permissions
             record_get_res = client.get(
-                url_for('b2share_records_rest.b2share_record_item',
+                url_for('b2share_records_rest.b2rec_item',
                         pid_value=recid),
                 headers=headers)
             # check that non-creator can access the metadata

--- a/tests/b2share_functional_tests/test_validation_errors.py
+++ b/tests/b2share_functional_tests/test_validation_errors.py
@@ -63,7 +63,7 @@ def make_record_json():
 
 
 record_list_url = (lambda **kwargs:
-                   url_for('b2share_records_rest.b2share_record_list',
+                   url_for('b2share_records_rest.b2rec_list',
                            **kwargs))
 
 
@@ -102,7 +102,7 @@ def post_record(client, record_json):
                                     headers=json_headers)
     assert record_create_res.status_code == 201
     record_create_data = json.loads(record_create_res.get_data(as_text=True))
-    record_url = url_for('b2share_records_rest.b2share_record_item',
+    record_url = url_for('b2share_records_rest.b2rec_item',
                          pid_value=record_create_data['id'])
     return (record_url, record_create_data)
 

--- a/tests/b2share_unit_tests/deposit/test_deposit_rest.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_rest.py
@@ -51,7 +51,7 @@ def test_deposit_create(app, test_records_data, test_users, login_user):
 
     def create_record(client, record_data):
         return client.post(
-            url_for('b2share_records_rest.b2share_record_list'),
+            url_for('b2share_records_rest.b2rec_list'),
             data=json.dumps(record_data),
             headers=headers
         )
@@ -97,7 +97,7 @@ def test_deposit_submit(app, test_records_data, draft_deposits, test_users,
             headers = [('Content-Type', 'application/json-patch+json'),
                        ('Accept', 'application/json')]
             draft_patch_res = client.patch(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=deposit.pid.pid_value),
                 data=json.dumps([{
                     "op": "replace", "path": "/publication_state",
@@ -149,7 +149,7 @@ def test_deposit_publish(app, test_users, test_communities,
             headers = [('Content-Type', 'application/json-patch+json'),
                        ('Accept', 'application/json')]
             draft_patch_res = client.patch(
-                url_for('b2share_deposit_rest.b2share_deposit_item',
+                url_for('b2share_deposit_rest.b2dep_item',
                         pid_value=deposit.pid.pid_value),
                 data=json.dumps([{
                     "op": "replace", "path": "/publication_state",
@@ -297,7 +297,7 @@ def test_deposit_create_permission(app, test_users, login_user,
                 if user is not None:
                     login_user(user, client)
                 draft_create_res = client.post(
-                    url_for('b2share_records_rest.b2share_record_list'),
+                    url_for('b2share_records_rest.b2rec_list'),
                     data=json.dumps(record_data),
                     headers=headers
                 )
@@ -341,7 +341,7 @@ def test_deposit_read_permissions(app, login_user, test_users,
                     login_user(user, client)
                 headers = [('Accept', 'application/json')]
                 request_res = client.get(
-                    url_for('b2share_deposit_rest.b2share_deposit_item',
+                    url_for('b2share_deposit_rest.b2dep_item',
                             pid_value=deposit.pid.pid_value),
                     headers=headers)
                 assert request_res.status_code == status
@@ -425,7 +425,7 @@ def test_deposit_search_permissions(app, draft_deposits, submitted_deposits,
         com_admin = create_user('com_admin', roles=[community.admin_role])
 
         search_deposits_url = url_for(
-            'b2share_records_rest.b2share_record_list', drafts=1, size=100)
+            'b2share_records_rest.b2rec_list', drafts=1, size=100)
         headers = [('Content-Type', 'application/json'),
                 ('Accept', 'application/json')]
 
@@ -487,7 +487,7 @@ def test_deposit_delete_permissions(app, test_records_data,
                     login_user(user, client)
                 headers = [('Accept', 'application/json')]
                 request_res = client.delete(
-                    url_for('b2share_deposit_rest.b2share_deposit_item',
+                    url_for('b2share_deposit_rest.b2dep_item',
                             pid_value=deposit.pid.pid_value),
                     headers=headers)
                 assert request_res.status_code == status
@@ -558,7 +558,7 @@ def test_deposit_submit_permissions(app, login_user, test_communities,
                 if user is not None:
                     login_user(user, client)
                 request_res = client.patch(
-                    url_for('b2share_deposit_rest.b2share_deposit_item',
+                    url_for('b2share_deposit_rest.b2dep_item',
                             pid_value=deposit.pid.pid_value),
                     data=json.dumps([{
                         "op": "replace", "path": "/publication_state",
@@ -603,7 +603,7 @@ def test_deposit_publish_permissions(app, login_user, test_communities,
                 if user is not None:
                     login_user(user, client)
                 request_res = client.patch(
-                    url_for('b2share_deposit_rest.b2share_deposit_item',
+                    url_for('b2share_deposit_rest.b2dep_item',
                             pid_value=deposit.pid.pid_value),
                     data=json.dumps([{
                         "op": "replace", "path": "/publication_state",
@@ -653,7 +653,7 @@ def test_deposit_modify_published_permissions(app, login_user, test_communities,
                 if user is not None:
                     login_user(user, client)
                 request_res = client.patch(
-                    url_for('b2share_deposit_rest.b2share_deposit_item',
+                    url_for('b2share_deposit_rest.b2dep_item',
                             pid_value=deposit.pid.pid_value),
                     data=json.dumps([{
                         "op": "replace", "path": "/publication_state",

--- a/tests/b2share_unit_tests/records/test_records_index.py
+++ b/tests/b2share_unit_tests/records/test_records_index.py
@@ -65,8 +65,8 @@ def test_record_indexing(app, test_users, test_records, script_info,
         # flush the indices so that indexed records are searchable
         current_search_client.indices.flush('*')
 
-        search_url = url_for('b2share_records_rest.b2share_record_list')
-        search_deposits_url = url_for('b2share_records_rest.b2share_record_list',
+        search_url = url_for('b2share_records_rest.b2rec_list')
+        search_deposits_url = url_for('b2share_records_rest.b2rec_list',
                                       drafts=1)
 
     headers = [('Content-Type', 'application/json'),

--- a/tests/b2share_unit_tests/records/test_records_rest.py
+++ b/tests/b2share_unit_tests/records/test_records_rest.py
@@ -61,7 +61,7 @@ def test_record_content(app, test_communities,
             login_user(creator, client)
             headers = [('Accept', 'application/json')]
             request_res = client.get(
-                url_for('b2share_records_rest.b2share_record_item',
+                url_for('b2share_records_rest.b2rec_item',
                         pid_value=record_pid.pid_value),
                 headers=headers)
 
@@ -127,7 +127,7 @@ def test_record_read_permissions(app, test_communities,
                     login_user(user, client)
                 headers = [('Accept', 'application/json')]
                 request_res = client.get(
-                    url_for('b2share_records_rest.b2share_record_item',
+                    url_for('b2share_records_rest.b2rec_item',
                             pid_value=pid.pid_value),
                     headers=headers)
 
@@ -184,7 +184,7 @@ def test_modify_metadata_published_record_permissions(app, test_communities,
                 headers = [('Content-Type', 'application/json-patch+json'),
                            ('Accept', 'application/json')]
                 request_res = client.patch(
-                    url_for('b2share_records_rest.b2share_record_item',
+                    url_for('b2share_records_rest.b2rec_item',
                             pid_value=record_pid.pid_value),
                     data=json.dumps(patch),
                     headers=headers)
@@ -197,7 +197,7 @@ def test_modify_metadata_published_record_permissions(app, test_communities,
                 headers = [('Content-Type', 'application/json'),
                            ('Accept', 'application/json')]
                 request_res = client.put(
-                    url_for('b2share_records_rest.b2share_record_item',
+                    url_for('b2share_records_rest.b2rec_item',
                             pid_value=record_pid.pid_value),
                     data=json.dumps(data),
                     headers=headers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ from invenio_access.models import ActionRoles
 from invenio_access.permissions import superuser_access
 from invenio_indexer.api import RecordIndexer
 from b2share.modules.communities.models import Community
+from sqlalchemy.exc import ProgrammingError
 
 from b2share.config import B2SHARE_RECORDS_REST_ENDPOINTS, \
     B2SHARE_DEPOSIT_REST_ENDPOINTS
@@ -98,6 +99,10 @@ def app(request, tmpdir):
 
     with app.app_context():
         if app.config['SQLALCHEMY_DATABASE_URI'] != 'sqlite://':
+            try:
+                drop_database(db.engine.url)
+            except ProgrammingError:
+                pass
             create_database(db.engine.url)
         db.create_all()
         for deleted in current_search.delete(ignore=[404]):

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -57,7 +57,7 @@ def test_demo_cmd_load(app):
             # assert result.exit_code == 0
             # FIXME: check that the config is loaded
 
-        resolver = Resolver(pid_type='b2share_record', object_type='rec',
+        resolver = Resolver(pid_type='b2rec', object_type='rec',
                             getter=partial(Record.get_record,
                                            with_deleted=True))
         # check that the loaded record exists


### PR DESCRIPTION
* Renames pid_types b2share_record and b2share_deposit as b2rec and
  b2dep (closes #1223).

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>