### PR TITLE
api: REST API input validation

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -40,6 +40,7 @@ from b2share.modules.deposit.permissions import (
     CreateDepositPermission, ReadDepositPermission,
     UpdateDepositPermission, DeleteDepositPermission,
 )
+from b2share.modules.deposit.loaders import patch_input_loader
 
 
 SUPPORT_EMAIL = None # must be setup in the local instances
@@ -79,8 +80,7 @@ B2SHARE_RECORDS_REST_ENDPOINTS = dict(
         links_factory_imp=('b2share.modules.records.links'
                            ':record_links_factory'),
         record_loaders={
-            'application/json-patch+json':
-            lambda: request.get_json(force=True),
+            'application/json-patch+json': patch_input_loader,
             'application/json':
             # FIXME: create a loader so that only allowed fields can be set
             lambda: request.get_json(),
@@ -119,11 +119,11 @@ B2SHARE_DEPOSIT_REST_ENDPOINTS = dict(
         },
         links_factory_imp='b2share.modules.deposit.links:deposit_links_factory',
         record_loaders={
-            'application/json-patch+json':
-            lambda: request.get_json(force=True),
+            'application/json-patch+json': patch_input_loader,
             'application/json':
-            # FIXME: create a loader so that only allowed fields can be set
             lambda: request.get_json(),
+            # FIXME: create a loader so that only allowed fields can be set
+            # lambda: request.get_json(),
             # 'b2share.modules.deposit.loaders:deposit_record_loader'
         },
         item_route='/records/<{0}:pid_value>/draft'.format(DEPOSIT_PID),

--- a/b2share/modules/deposit/permissions.py
+++ b/b2share/modules/deposit/permissions.py
@@ -46,6 +46,7 @@ from b2share.modules.communities.api import Community
 from invenio_db import db
 
 from .api import PublicationStates
+from .loaders import patch_input_loader
 
 
 def _deposit_need_factory(name, **kwargs):
@@ -245,24 +246,22 @@ class UpdateDepositPermission(DepositPermission):
         new_deposit = None
         # Check submit/publish actions
         if (request.method == 'PATCH' and
-                request.content_type == 'application/json-patch+json'):
+            request.content_type == 'application/json-patch+json'):
             # FIXME: need some optimization on Invenio side. We are applying
             # the patch twice
-            patch = request.get_json(force=True)
-            if patch is None:
-                abort(400)
+            patch = patch_input_loader(self.deposit)
             new_deposit = deepcopy(self.deposit)
             try:
                 apply_patch(new_deposit, patch, in_place=True)
             except JsonPatchException:
                 abort(400)
-        elif (request.method == 'PUT' and
-                request.content_type == 'application/json'):
-            new_deposit = request.get_json()
-            if new_deposit is None:
-                abort(400)
+        # elif (request.method == 'PUT' and
+        #         request.content_type == 'application/json'):
+            # new_deposit = put_input_loader(self.deposit)
+            # if new_deposit is None:
+            #     abort(400)
         else:
-            return
+            abort(400)
 
         # Create permission for updating the state_field
         if (new_deposit is not None and new_deposit['publication_state']

--- a/b2share/modules/deposit/views.py
+++ b/b2share/modules/deposit/views.py
@@ -24,7 +24,7 @@
 
 from functools import partial
 
-from flask import Blueprint, current_app, g, request
+from flask import abort, Blueprint, current_app, g, request
 from invenio_files_rest.errors import InvalidOperationError
 from invenio_pidstore.errors import PIDInvalidAction
 from invenio_pidstore.resolver import Resolver
@@ -174,10 +174,11 @@ class DepositResource(RecordResource):
 
     def put(self, *args, **kwargs):
         """PUT the deposit."""
-        pid, record = request.view_args['pid_value'].data
-        result = super(DepositResource, self).patch(*args, **kwargs)
-        self._index_record(record)
-        return result
+        abort(405)
+        # pid, record = request.view_args['pid_value'].data
+        # result = super(DepositResource, self).put(*args, **kwargs)
+        # self._index_record(record)
+        # return result
 
     def _index_record(self, record):
         """Index the published record if the deposit is published."""

--- a/b2share/modules/records/views.py
+++ b/b2share/modules/records/views.py
@@ -192,8 +192,8 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
         item_links_factory=links_factory,
         record_class=Deposit,
     )
-    item_view = RecordResource.as_view(
-        RecordResource.view_name.format(endpoint),
+    item_view = B2ShareRecordResource.as_view(
+        B2ShareRecordResource.view_name.format(endpoint),
         resolver=resolver,
         read_permission_factory=read_permission_factory,
         update_permission_factory=update_permission_factory,
@@ -302,6 +302,15 @@ class B2ShareRecordsListResource(RecordsListResource):
         location = url_for(endpoint, pid_value=pid.pid_value, _external=True)
         response.headers.extend(dict(location=location))
         return response
+
+
+class B2ShareRecordResource(RecordResource):
+    """B2Share resource for records."""
+
+    def put(*args, **kwargs):
+        """Disable PUT."""
+        abort(405)
+
 
 class RecordsAbuseResource(RecordResource):
 


### PR DESCRIPTION
* Prevents records immutable fields from being modified using the
  REST API PATCH method. (addresses #1172)

* Disables record REST API PUT method.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>