### PR TITLE
global: root schema constraints fix

### DIFF
--- a/b2share/modules/schemas/root_schemas/root_schema_v0.json
+++ b/b2share/modules/schemas/root_schemas/root_schema_v0.json
@@ -17,6 +17,7 @@
                             "type": "string"
                         }
                     },
+                    "additionalProperties": false,
                     "required": ["creator_name"]
                 },
                 "uniqueItems": true
@@ -32,6 +33,7 @@
                             "type": "string"
                         }
                     },
+                    "additionalProperties": false,
                     "required": ["title"]
                 },
                 "minItems": 1,
@@ -81,6 +83,7 @@
                             "enum": ["ContactPerson", "DataCollector", "DataCurator", "DataManager", "Distributor", "Editor", "HostingInstitution", "Producer", "ProjectLeader", "ProjectManager", "ProjectMember", "RegistrationAgency", "RegistrationAuthority", "RelatedPerson", "Researcher", "ResearchGroup", "RightsHolder", "Sponsor", "Supervisor", "WorkPackageLeader", "Other"]
                         }
                     },
+                    "additionalProperties": false,
                     "required": ["contributor_name", "contributor_type"]
                 },
                 "uniqueItems": true
@@ -106,6 +109,7 @@
                             "enum": ["Audiovisual", "Collection", "Dataset", "Event", "Image", "InteractiveResource", "Model", "PhysicalObject", "Service", "Software", "Sound", "Text", "Workflow", "Other"]
                         }
                     },
+                    "additionalProperties": false,
                     "required": ["resource_type_general"]
                 },
                 "minItems": 1,
@@ -126,6 +130,7 @@
                             "type": "string"
                         }
                     },
+                    "additionalProperties": false,
                     "required": ["alternate_identifier", "alternate_identifier_type"]
                 },
                 "uniqueItems": true
@@ -145,6 +150,7 @@
                             "enum": ["Abstract", "Methods", "SeriesInformation", "TableOfContents", "TechnicalInfo", "Other"]
                         }
                     },
+                    "additionalProperties": false,
                     "required": ["description", "description_type"]
                 },
                 "uniqueItems": true
@@ -187,6 +193,7 @@
                         "format": "uri"
                     }
                 },
+                "additionalProperties": false,
                 "required": ["license"]
             },
 
@@ -222,7 +229,7 @@
                 "type": "array"
             }
         },
-        "required": ["community", "titles", "open_access", "publication_state"],
+        "required": ["community", "titles", "open_access", "publication_state", "community_specific"],
         "additionalProperties": false,
         "b2share": {
             "presentation": {

--- a/tests/b2share_unit_tests/deposit/test_deposit_api.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_api.py
@@ -99,6 +99,31 @@ def test_deposit_update_unknown_publication_state(app, draft_deposits):
             deposit.commit()
 
 
+def test_deposit_add_unknown_fields(app, draft_deposits):
+    """Test adding unknown fields in deposit. It should fail."""
+    for path in [
+        # all the following paths point to "object" fields in
+        # in the root JSON Schema
+        '/new_field',
+        '/community_specific/new_field',
+        '/creators/0/new_field',
+        '/titles/0/new_field',
+        '/contributors/0/new_field',
+        '/resource_types/0/new_field',
+        '/alternate_identifiers/0/new_field',
+        '/descriptions/0/new_field',
+        '/license/new_field',
+    ]:
+        with app.app_context():
+            deposit = Deposit.get_record(draft_deposits[0].id)
+            deposit = deposit.patch([
+                {'op': 'add', 'path': path, 'value': 'any value'}
+            ])
+            with pytest.raises(ValidationError):
+                deposit.commit()
+
+
+
 def test_deposit_create_with_invalid_community_fails(app,
                                                      test_records_data):
     """Test deposit creation without or with an invalid community fails."""

--- a/tests/b2share_unit_tests/records/test_records_api.py
+++ b/tests/b2share_unit_tests/records/test_records_api.py
@@ -30,6 +30,7 @@ import pytest
 from jsonschema.exceptions import ValidationError
 from b2share.modules.records.errors import AlteredRecordError
 from invenio_records import Record
+from b2share.modules.deposit.api import Deposit
 
 
 def test_change_record_schema_fails(app, test_records):
@@ -54,3 +55,43 @@ def test_change_record_community(app, test_records):
         record['community'] = str(uuid.uuid4())
         with pytest.raises(AlteredRecordError):
             record.commit()
+
+
+def test_record_add_unknown_fields(app, test_records):
+    """Test adding unknown fields in a record. It should fail."""
+    for path in [
+        # all the following paths point to "object" fields in
+        # in the root JSON Schema
+        '/new_field',
+        '/community_specific/new_field',
+        '/creators/0/new_field',
+        '/titles/0/new_field',
+        '/contributors/0/new_field',
+        '/resource_types/0/new_field',
+        '/alternate_identifiers/0/new_field',
+        '/descriptions/0/new_field',
+        '/license/new_field',
+    ]:
+        with app.app_context():
+            record = Record.get_record(test_records[0].record_id)
+            record = record.patch([
+                {'op': 'add', 'path': path, 'value': 'any value'}
+            ])
+            with pytest.raises(ValidationError):
+                record.commit()
+
+
+def test_record_commit_with_incomplete_metadata(app,
+                                                test_incomplete_records_data):
+    """Test commit of an incomplete record fails."""
+    for data in test_incomplete_records_data:
+        with app.app_context():
+            deposit = Deposit.create(data.complete_data)
+            deposit.submit()
+            deposit.publish()
+            deposit.commit()
+            pid, record = deposit.fetch_published()
+            # make the data incomplete
+            record = record.patch(data.patch)
+            with pytest.raises(ValidationError):
+                record.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,12 @@ def test_incomplete_records_data(app, test_communities):
         # no title
             { "op": "remove", "path": "/titles"}
         ], [
+        # no community_specific
+            {
+                "op": "remove",
+                "path": "/community_specific"
+            }
+        ], [
         # no study_design
             {
                 "op": "remove",


### PR DESCRIPTION
* FIX Makes community_specific field required (closes #1067).

* FIX Forbids additional properties in every object field of the
  root schema. (closes #1238)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>