### PR TITLE
api: access request and abuse report fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,8 @@ def app(request, tmpdir):
         CELERY_ALWAYS_EAGER=True,
         CELERY_RESULT_BACKEND="cache",
         CELERY_CACHE_BACKEND="memory",
-        CELERY_EAGER_PROPAGATES_EXCEPTIONS=True
+        CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+        SUPPORT_EMAIL='support@eudat.eu',
     )
 
     # update the application with the configuration provided by the test


### PR DESCRIPTION
* FIX Sends email to contact_email or owners instead of sending it
  to support. (closes #1239)

* FIX RecordsAbuseResource and RequestAccessResource are now
  subclasses of ContentNegotiatedMethodView instead of
  RecordResource. (closes #1245)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>