### PR TITLE
Fix http api documentation

### DIFF
--- a/webui/src/components/editfiles.jsx
+++ b/webui/src/components/editfiles.jsx
@@ -556,7 +556,7 @@ export const FileRecordRow = React.createClass({
                             </div>
                         </div> : false }
                         { file.ePIC_PID ? <div className="row">
-                            <div className="col-sm-12"><span style={{marginLeft:'2.5em'}}/>
+                            <div className="col-sm-12"><span style={{marginLeft:'2.5em', whiteSpace: 'nowrap'}}/>
                                 PID: <PersistentIdentifier style={{marginLeft:'0.2em'}} pid={file.ePIC_PID} />
                             </div>
                         </div> : false }

--- a/webui/src/docs/rest-api.jsx
+++ b/webui/src/docs/rest-api.jsx
@@ -423,7 +423,7 @@ module.exports = function() {
                 will end in '/draft/'</p></li>
         </ul>
         <Example>
-            {'curl -i -H "Content-Type:application/json" -d \'{"titles":[{"title":"TestRest"}], "community":"e9b9792e-79fb-4b07-b6b4-b9c2bd06d095", "open_access":true}\' -X POST https://$HOSTNAME/api/records/?access_token=$ACCESS_TOKEN'}
+            {'curl -i -H "Content-Type:application/json" -d \'{"titles":[{"title":"TestRest"}], "community":"e9b9792e-79fb-4b07-b6b4-b9c2bd06d095", "open_access":true, "community_specific": {}}\' -X POST https://$HOSTNAME/api/records/?access_token=$ACCESS_TOKEN'}
             <Returns>
             {{
               "created": "2016-10-24T12:21:21.697737+00:00",
@@ -436,6 +436,7 @@ module.exports = function() {
               "metadata": {
                 "$schema": "https://trng-b2share.eudat.eu/api/communities/e9b9792e-79fb-4b07-b6b4-b9c2bd06d095/schemas/0#/draft_json_schema",
                 "community": "e9b9792e-79fb-4b07-b6b4-b9c2bd06d095",
+                "community_specific": {},
                 "open_access": true,
                 "owners": [
                   8
@@ -506,6 +507,7 @@ module.exports = function() {
               "metadata": {
                 "$schema": "https://trng-b2share.eudat.eu/api/communities/e9b9792e-79fb-4b07-b6b4-b9c2bd06d095/schemas/0#/draft_json_schema",
                 "community": "e9b9792e-79fb-4b07-b6b4-b9c2bd06d095",
+                "community_specific": {},
                 "keywords": [
                   "keyword1",
                   "keyword2"
@@ -554,6 +556,7 @@ module.exports = function() {
                 "$schema": "https://trng-b2share.eudat.eu/api/communities/e9b9792e-79fb-4b07-b6b4-b9c2bd06d095/schemas/0#/draft_json_schema",
                 "DOI": "10.5072/b2share.cdb15c27-326e-4e95-b812-6b1c6b54c299",
                 "community": "e9b9792e-79fb-4b07-b6b4-b9c2bd06d095",
+                "community_specific": {},
                 "keywords": [
                   "keyword1",
                   "keyword2"


### PR DESCRIPTION
`community_specific` is a required property now, should be included by default in our examples