### PR TITLE
Update record files quota

### DIFF
--- a/demo/b2share_demo/config.py
+++ b/demo/b2share_demo/config.py
@@ -26,7 +26,11 @@
 from __future__ import absolute_import, print_function
 
 
-FILES_REST_DEFAULT_MAX_FILE_SIZE = 10000 * 1024 * 1024 # 10 GB for RC4 demo
+FILES_REST_DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024 * 1024 # 10 GB per file
+"""Maximum file size for the files in a record"""
+FILES_REST_DEFAULT_QUOTA_SIZE    = 20 * 1024 * 1024 * 1024 # 20 GB per record
+"""Quota size for the files in a record"""
+
 
 # Not using staging server for public deployments anymore
 OAUTHCLIENT_REMOTE_APPS = dict(


### PR DESCRIPTION
The total space taken by a file bucket (files in a record) can be checked programmatically, via the HTTP API:

`https://b2share.local/api/files/ba937cdb-93ff-4b47-b79b-4159c36f9144` -> quota_size