### PR TITLE
views: unused REST endpoints disabled

### DIFF
--- a/b2share/modules/communities/views.py
+++ b/b2share/modules/communities/views.py
@@ -152,46 +152,46 @@ class CommunityListResource(ContentNegotiatedMethodView):
         # TODO: set etag
         return response
 
-    def post(self):
-        """Create a new community."""
-        if request.content_type != 'application/json':
-            abort(415)
-        data = request.get_json()
-        if data is None:
-            return abort(400)
-        # check user permissions
-        if (not current_communities.rest_access_control_disabled and
-                not communities_create_all_permission.can()):
-            from flask_login import current_user
-            if not current_user.is_authenticated:
-                abort(401)
-            abort(403)
+    # def post(self):
+    #     """Create a new community."""
+    #     if request.content_type != 'application/json':
+    #         abort(415)
+    #     data = request.get_json()
+    #     if data is None:
+    #         return abort(400)
+    #     # check user permissions
+    #     if (not current_communities.rest_access_control_disabled and
+    #             not communities_create_all_permission.can()):
+    #         from flask_login import current_user
+    #         if not current_user.is_authenticated:
+    #             abort(401)
+    #         abort(403)
 
-        try:
-            community = Community.create_community(**data)
-            response = self.make_response(
-                community=community,
-                code=201,
-            )
-            # set the header's Location field.
-            response.headers['Location'] = community_self_link(community)
-            db.session.commit()
-            return response
-        except InvalidCommunityError as e1:
-            try:
-                db.session.rollback()
-            except Exception as e2:
-                raise e2 from e1
-            abort(400)
-        except Exception as e1:
-            try:
-                db.session.rollback()
-            except Exception as e2:
-                raise e2 from e1
-            if isinstance(e1, HTTPException):
-                raise e1
-            current_app.logger.exception('Failed to create record.')
-            abort(500)
+    #     try:
+    #         community = Community.create_community(**data)
+    #         response = self.make_response(
+    #             community=community,
+    #             code=201,
+    #         )
+    #         # set the header's Location field.
+    #         response.headers['Location'] = community_self_link(community)
+    #         db.session.commit()
+    #         return response
+    #     except InvalidCommunityError as e1:
+    #         try:
+    #             db.session.rollback()
+    #         except Exception as e2:
+    #             raise e2 from e1
+    #         abort(400)
+    #     except Exception as e1:
+    #         try:
+    #             db.session.rollback()
+    #         except Exception as e2:
+    #             raise e2 from e1
+    #         if isinstance(e1, HTTPException):
+    #             raise e1
+    #         current_app.logger.exception('Failed to create record.')
+    #         abort(500)
 
 
 class CommunityResource(ContentNegotiatedMethodView):
@@ -216,23 +216,23 @@ class CommunityResource(ContentNegotiatedMethodView):
             default_media_type='application/json',
             **kwargs)
 
-    @pass_community
-    @need_community_permission(delete_permission_factory)
-    def delete(self, community, **kwargs):
-        """Delete a community."""
-        # check the ETAG
-        self.check_etag(str(community.updated))
-        try:
-            community.delete()
-            db.session.commit()
-        except Exception as e1:
-            current_app.logger.exception('Failed to create record.')
-            try:
-                db.session.rollback()
-            except Exception as e2:
-                raise e2 from e1
-            abort(500)
-        return '', 204
+    # @pass_community
+    # @need_community_permission(delete_permission_factory)
+    # def delete(self, community, **kwargs):
+    #     """Delete a community."""
+    #     # check the ETAG
+    #     self.check_etag(str(community.updated))
+    #     try:
+    #         community.delete()
+    #         db.session.commit()
+    #     except Exception as e1:
+    #         current_app.logger.exception('Failed to create record.')
+    #         try:
+    #             db.session.rollback()
+    #         except Exception as e2:
+    #             raise e2 from e1
+    #         abort(500)
+    #     return '', 204
 
     @pass_community
     @need_community_permission(read_permission_factory)
@@ -242,64 +242,64 @@ class CommunityResource(ContentNegotiatedMethodView):
         self.check_etag(str(community.updated))
         return community
 
-    @require_content_types('application/json-patch+json', 'application/json')
-    @pass_community
-    @need_community_permission(update_permission_factory)
-    def patch(self, community, **kwargs):
-        """Patch a community."""
-        # check the ETAG
-        self.check_etag(str(community.updated))
+    # @require_content_types('application/json-patch+json', 'application/json')
+    # @pass_community
+    # @need_community_permission(update_permission_factory)
+    # def patch(self, community, **kwargs):
+    #     """Patch a community."""
+    #     # check the ETAG
+    #     self.check_etag(str(community.updated))
 
-        data = request.get_json(force=True)
-        if data is None:
-            abort(400)
-        try:
-            if 'application/json' == request.content_type:
-                community.update(data)
-            else:
-                community = community.patch(data)
-            db.session.commit()
-            return community
-        except (JsonPatchConflict):
-            abort(409)
-        except (JsonPatchException, InvalidJsonPatch):
-            abort(400)
-        except InvalidCommunityError:
-            db.session.rollback()
-            abort(400)
-        except Exception as e1:
-            current_app.logger.exception('Failed to patch record.')
-            try:
-                db.session.rollback()
-            except Exception as e2:
-                raise e2 from e1
-            abort(500)
+    #     data = request.get_json(force=True)
+    #     if data is None:
+    #         abort(400)
+    #     try:
+    #         if 'application/json' == request.content_type:
+    #             community.update(data)
+    #         else:
+    #             community = community.patch(data)
+    #         db.session.commit()
+    #         return community
+    #     except (JsonPatchConflict):
+    #         abort(409)
+    #     except (JsonPatchException, InvalidJsonPatch):
+    #         abort(400)
+    #     except InvalidCommunityError:
+    #         db.session.rollback()
+    #         abort(400)
+    #     except Exception as e1:
+    #         current_app.logger.exception('Failed to patch record.')
+    #         try:
+    #             db.session.rollback()
+    #         except Exception as e2:
+    #             raise e2 from e1
+    #         abort(500)
 
-    @require_content_types('application/json')
-    @pass_community
-    @need_community_permission(update_permission_factory)
-    def put(self, community, **kwargs):
-        """Put a community."""
-        # check the ETAG
-        self.check_etag(str(community.updated))
+    # @require_content_types('application/json')
+    # @pass_community
+    # @need_community_permission(update_permission_factory)
+    # def put(self, community, **kwargs):
+    #     """Put a community."""
+    #     # check the ETAG
+    #     self.check_etag(str(community.updated))
 
-        data = request.get_json(force=True)
-        if data is None:
-            abort(400)
-        try:
-            community.update(data, clear_fields=True)
-            db.session.commit()
-            return community
-        except InvalidCommunityError:
-            db.session.rollback()
-            abort(400)
-        except Exception as e1:
-            current_app.logger.exception('Failed to patch record.')
-            try:
-                db.session.rollback()
-            except Exception as e2:
-                raise e2 from e1
-            abort(500)
+    #     data = request.get_json(force=True)
+    #     if data is None:
+    #         abort(400)
+    #     try:
+    #         community.update(data, clear_fields=True)
+    #         db.session.commit()
+    #         return community
+    #     except InvalidCommunityError:
+    #         db.session.rollback()
+    #         abort(400)
+    #     except Exception as e1:
+    #         current_app.logger.exception('Failed to patch record.')
+    #         try:
+    #             db.session.rollback()
+    #         except Exception as e2:
+    #             raise e2 from e1
+    #         abort(500)
 
 blueprint.add_url_rule('/',
                        view_func=CommunityListResource

--- a/b2share/modules/schemas/views.py
+++ b/b2share/modules/schemas/views.py
@@ -111,27 +111,27 @@ class BlockSchemaVersionResource(ContentNegotiatedMethodView):
         self.check_etag(str(block_schema_version.released))
         return block_schema_version
 
-    def put(self, schema_id, schema_version_nb):
-        """Create a new version of the schema."""
-        block_schema = BlockSchema.get_block_schema(schema_id)
+    # def put(self, schema_id, schema_version_nb):
+    #     """Create a new version of the schema."""
+    #     block_schema = BlockSchema.get_block_schema(schema_id)
 
-        data = request.get_json()
-        if data is None:
-            return abort(400)
+    #     data = request.get_json()
+    #     if data is None:
+    #         return abort(400)
 
-        try:
-            schema = block_schema.create_version(
-                                                data['json_schema'],
-                                                int(schema_version_nb)
-                                                )
-        except InvalidSchemaVersionError as e:
-            abort(400, str(e))
-        except SchemaVersionExistsError as e:
-            abort(409, str(e))
-        return self.make_response(
-            block_schema_version=schema,
-            code=201,
-        )
+    #     try:
+    #         schema = block_schema.create_version(
+    #                                             data['json_schema'],
+    #                                             int(schema_version_nb)
+    #                                             )
+    #     except InvalidSchemaVersionError as e:
+    #         abort(400, str(e))
+    #     except SchemaVersionExistsError as e:
+    #         abort(409, str(e))
+    #     return self.make_response(
+    #         block_schema_version=schema,
+    #         code=201,
+    #     )
 
 
 def pass_community_schema(f):
@@ -209,19 +209,19 @@ class BlockSchemaListResource(ContentNegotiatedMethodView):
             schemas=schemas,
             code=200)
 
-    def post(self):
-        """Create a new schema."""
-        if request.content_type != 'application/json':
-            abort(415)
-        data = request.get_json()
-        if data is None:
-            return abort(400)
+    # def post(self):
+    #     """Create a new schema."""
+    #     if request.content_type != 'application/json':
+    #         abort(415)
+    #     data = request.get_json()
+    #     if data is None:
+    #         return abort(400)
 
-        schema = BlockSchema.create_block_schema(**data)
-        return self.make_response(
-            schema=schema,
-            code=201,
-        )
+    #     schema = BlockSchema.create_block_schema(**data)
+    #     return self.make_response(
+    #         schema=schema,
+    #         code=201,
+    #     )
 
 
 class BlockSchemaResource(ContentNegotiatedMethodView):
@@ -247,39 +247,39 @@ class BlockSchemaResource(ContentNegotiatedMethodView):
             code=200
         )
 
-    def patch(self, schema_id):
-        """Patch a schema."""
-        data = request.get_json(force=True)
-        if data is None:
-            abort(400)
+    # def patch(self, schema_id):
+    #     """Patch a schema."""
+    #     data = request.get_json(force=True)
+    #     if data is None:
+    #         abort(400)
 
-        block_schema = BlockSchema.get_block_schema(schema_id)
-        self.check_etag(str(block_schema.updated))
+    #     block_schema = BlockSchema.get_block_schema(schema_id)
+    #     self.check_etag(str(block_schema.updated))
 
-        try:
-            if 'application/json' == request.content_type:
-                block_schema.update(data)
-            else:
-                block_schema = block_schema.patch(data)
-            db.session.commit()
-            return self.make_response(
-                schema=block_schema,
-                code=200
-            )
-        except (JsonPatchConflict):
-            abort(409)
-        except (JsonPatchException):
-            abort(400)
-        except InvalidBlockSchemaError:
-            db.session.rollback()
-            abort(400)
-        except Exception as e1:
-            current_app.logger.exception('Failed to patch record.')
-            try:
-                db.session.rollback()
-            except Exception as e2:
-                raise e2 from e1
-            abort(500)
+    #     try:
+    #         if 'application/json' == request.content_type:
+    #             block_schema.update(data)
+    #         else:
+    #             block_schema = block_schema.patch(data)
+    #         db.session.commit()
+    #         return self.make_response(
+    #             schema=block_schema,
+    #             code=200
+    #         )
+    #     except (JsonPatchConflict):
+    #         abort(409)
+    #     except (JsonPatchException):
+    #         abort(400)
+    #     except InvalidBlockSchemaError:
+    #         db.session.rollback()
+    #         abort(400)
+    #     except Exception as e1:
+    #         current_app.logger.exception('Failed to patch record.')
+    #         try:
+    #             db.session.rollback()
+    #         except Exception as e2:
+    #             raise e2 from e1
+    #         abort(500)
 
 
 blueprint.add_url_rule(

--- a/tests/b2share_unit_tests/communities/test_communities_rest.py
+++ b/tests/b2share_unit_tests/communities/test_communities_rest.py
@@ -49,126 +49,128 @@ community_with_and_without_access_control = pytest.mark.parametrize('app', [({
     indirect=['app'])
 
 
-@community_with_and_without_access_control
-def test_valid_create(app, login_user,
-                      communities_permissions):
-    """Test VALID community creation request (POST .../communities/)."""
-    with app.app_context():
-        allowed_user = create_user('allowed')
-        communities_permissions(allowed_user.id).create_permission(True)
-        communities_permissions(allowed_user.id).read_permission(True)
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_valid_create(app, login_user,
+#                       communities_permissions):
+#     """Test VALID community creation request (POST .../communities/)."""
+#     with app.app_context():
+#         allowed_user = create_user('allowed')
+#         communities_permissions(allowed_user.id).create_permission(True)
+#         communities_permissions(allowed_user.id).read_permission(True)
+#         db.session.commit()
 
-    with app.test_client() as client:
-        with app.app_context():
-            login_user(allowed_user, client)
+#     with app.test_client() as client:
+#         with app.app_context():
+#             login_user(allowed_user, client)
 
-            headers = [('Content-Type', 'application/json'),
-                        ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list',
-                                      _external=False),
-                                data=json.dumps(community_metadata),
-                                headers=headers)
-            assert res.status_code == 201
-            # check that the returned community matches the given data
-            response_data = json.loads(res.get_data(as_text=True))
-            for field, value in community_metadata.items():
-                assert response_data[field] == value
+#             headers = [('Content-Type', 'application/json'),
+#                         ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list',
+#                                       _external=False),
+#                                 data=json.dumps(community_metadata),
+#                                 headers=headers)
+#             assert res.status_code == 201
+#             # check that the returned community matches the given data
+#             response_data = json.loads(res.get_data(as_text=True))
+#             for field, value in community_metadata.items():
+#                 assert response_data[field] == value
 
-            # check that an internal community returned id and that it contains
-            # the same data
-            assert 'id' in response_data.keys()
-            assert response_data['id'] == str(Community.get(
-                name=community_metadata['name']).id)
-            headers = res.headers
-            community_id = response_data['id']
+#             # check that an internal community returned id and that it contains
+#             # the same data
+#             assert 'id' in response_data.keys()
+#             assert response_data['id'] == str(Community.get(
+#                 name=community_metadata['name']).id)
+#             headers = res.headers
+#             community_id = response_data['id']
 
-    with app.app_context():
-        communities_permissions(
-            allowed_user.id).read_permission(True, community_id)
-        db.session.commit()
+#     with app.app_context():
+#         communities_permissions(
+#             allowed_user.id).read_permission(True, community_id)
+#         db.session.commit()
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # check that the returned self link returns the same data
-            subtest_self_link(response_data, headers, client)
-            assert headers['Location'] == response_data['links']['self']
-        # check that one community has been created
-        assert len(CommunityModel.query.all()) == 1
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # check that the returned self link returns the same data
+#             subtest_self_link(response_data, headers, client)
+#             assert headers['Location'] == response_data['links']['self']
+#         # check that one community has been created
+#         assert len(CommunityModel.query.all()) == 1
 
 
-@community_with_and_without_access_control
-def test_invalid_create(app, login_user,
-                        communities_permissions):
-    """Test INVALID community creation request (POST .../communities/)."""
-    with app.app_context():
-        allowed_user = create_user('allowed')
-        communities_permissions(allowed_user.id).create_permission(True)
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_invalid_create(app, login_user,
+#                         communities_permissions):
+#     """Test INVALID community creation request (POST .../communities/)."""
+#     with app.app_context():
+#         allowed_user = create_user('allowed')
+#         communities_permissions(allowed_user.id).create_permission(True)
+#         db.session.commit()
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # check that creating with non accepted format will return 406
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'video/mp4')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 406
-        # check that no community has been created
-        assert len(CommunityModel.query.all()) == 0
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # check that creating with non accepted format will return 406
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'video/mp4')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 406
+#         # check that no community has been created
+#         assert len(CommunityModel.query.all()) == 0
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # Check that creating with non-json Content-Type will return 400
-            headers = [('Content-Type', 'video/mp4'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 415
-        # check that no community has been created
-        assert len(CommunityModel.query.all()) == 0
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # Check that creating with non-json Content-Type will return 400
+#             headers = [('Content-Type', 'video/mp4'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 415
+#         # check that no community has been created
+#         assert len(CommunityModel.query.all()) == 0
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # check that creating with invalid json will return 400
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data='{fdssfd',
-                              headers=headers)
-            assert res.status_code == 400
-        # check that no community has been created
-        assert len(CommunityModel.query.all()) == 0
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # check that creating with invalid json will return 400
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data='{fdssfd',
+#                               headers=headers)
+#             assert res.status_code == 400
+#         # check that no community has been created
+#         assert len(CommunityModel.query.all()) == 0
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # check that creating with no content will return 400
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              headers=headers)
-            assert res.status_code == 400
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # check that creating with no content will return 400
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               headers=headers)
+#             assert res.status_code == 400
 
-            # Bad internal error:
-            with patch('b2share.modules.communities.views.db.session.commit') \
-                    as mock:
-                mock.side_effect = Exception()
+#             # Bad internal error:
+#             with patch('b2share.modules.communities.views.db.session.commit') \
+#                     as mock:
+#                 mock.side_effect = Exception()
 
-                headers = [('Content-Type', 'application/json'),
-                           ('Accept', 'application/json')]
-                res = client.post(url_for('b2share_communities.communities_list'),
-                                  data=json.dumps(community_metadata),
-                                  headers=headers)
-                assert res.status_code == 500
-        # check that no community has been created
-        assert len(CommunityModel.query.all()) == 0
+#                 headers = [('Content-Type', 'application/json'),
+#                            ('Accept', 'application/json')]
+#                 res = client.post(url_for('b2share_communities.communities_list'),
+#                                   data=json.dumps(community_metadata),
+#                                   headers=headers)
+#                 assert res.status_code == 500
+#         # check that no community has been created
+#         assert len(CommunityModel.query.all()) == 0
 
 
 @community_with_and_without_access_control
@@ -252,273 +254,280 @@ def test_invalid_get(app, login_user,
             assert res.status_code == 406
 
 
-@community_with_and_without_access_control
-def test_valid_patch(app, login_user,
-                     communities_permissions, patch_community_function):
-    """Test VALID community patch request (PATCH .../communities/<id>)."""
-    with app.app_context():
-        # create community
-        created_community = Community.create_community(**community_metadata)
-        community_id = created_community.id
-        # create allowed user
-        allowed_user = create_user('allowed')
-        communities_permissions(
-            allowed_user.id).update_permission(True, community_id)
-        communities_permissions(
-            allowed_user.id).read_permission(True, community_id)
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_valid_patch(app, login_user,
+#                      communities_permissions, patch_community_function):
+#     """Test VALID community patch request (PATCH .../communities/<id>)."""
+#     with app.app_context():
+#         # create community
+#         created_community = Community.create_community(**community_metadata)
+#         community_id = created_community.id
+#         # create allowed user
+#         allowed_user = create_user('allowed')
+#         communities_permissions(
+#             allowed_user.id).update_permission(True, community_id)
+#         communities_permissions(
+#             allowed_user.id).read_permission(True, community_id)
+#         db.session.commit()
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            res = patch_community_function(community_id, client)
-            assert res.status_code == 200
-            # check that the returned community matches the given data
-            response_data = json.loads(res.get_data(as_text=True))
-            for field, value in patched_community_metadata.items():
-                assert response_data[field] == value
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             res = patch_community_function(community_id, client)
+#             assert res.status_code == 200
+#             # check that the returned community matches the given data
+#             response_data = json.loads(res.get_data(as_text=True))
+#             for field, value in patched_community_metadata.items():
+#                 assert response_data[field] == value
 
-            # check that an internal community returned id and that it contains
-            # the same data
-            assert 'id' in response_data.keys()
-            assert response_data['id'] == str(Community.get(
-                name=patched_community_metadata['name']).id)
-            headers = res.headers
+#             # check that an internal community returned id and that it contains
+#             # the same data
+#             assert 'id' in response_data.keys()
+#             assert response_data['id'] == str(Community.get(
+#                 name=patched_community_metadata['name']).id)
+#             headers = res.headers
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # check that the returned self link returns the same data
-            subtest_self_link(response_data, headers, client)
-
-
-@community_with_and_without_access_control
-def test_invalid_patch(app, login_user,
-                       communities_permissions):
-    """Test INVALID community patch request (PATCH .../communities/<id>)."""
-    with app.app_context():
-        # create user allowed to update all records
-        allowed_user = create_user('allowed')
-        communities_permissions(
-            allowed_user.id).update_permission(True, None)
-        db.session.commit()
-
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            unknown_uuid = uuid.uuid4()
-            # check that PATCH with non existing id will return 404
-            headers = [('Content-Type', 'application/json-patch+json'),
-                       ('Accept', 'application/json')]
-            res = client.patch(url_for('b2share_communities.communities_item',
-                                       community_id=unknown_uuid),
-                               data=json.dumps(community_patch),
-                               headers=headers)
-            assert res.status_code == 404
-
-            # create community
-            created_community = Community.create_community(
-                **community_metadata)
-            community_id = created_community.id
-            db.session.commit()
-
-            # check that PATCH with non accepted format will return 406
-            headers = [('Content-Type', 'application/json-patch+json'),
-                       ('Accept', 'video/mp4')]
-            res = client.patch(url_for('b2share_communities.communities_item',
-                                       community_id=community_id),
-                               data=json.dumps(community_patch),
-                               headers=headers)
-            assert res.status_code == 406
-
-            # check that PATCH with non-json Content-Type will return 415
-            headers = [('Content-Type', 'video/mp4'),
-                       ('Accept', 'application/json')]
-            res = client.patch(url_for('b2share_communities.communities_item',
-                                       community_id=community_id),
-                               data=json.dumps(community_patch),
-                               headers=headers)
-            assert res.status_code == 415
-
-            # check that PATCH with invalid json-patch will return 400
-            headers = [('Content-Type', 'application/json-patch+json'),
-                       ('Accept', 'application/json')]
-            res = client.patch(url_for('b2share_communities.communities_item',
-                                       community_id=community_id),
-                               data=json.dumps([
-                                   {'invalid': 'json-patch'}
-                               ]),
-                               headers=headers)
-            assert res.status_code == 400
-
-            # check that PATCH with invalid json will return 400
-            headers = [('Content-Type', 'application/json-patch+json'),
-                       ('Accept', 'application/json')]
-            res = client.patch(url_for('b2share_communities.communities_item',
-                                       community_id=community_id),
-                               data='{sdfsdf',
-                               headers=headers)
-            assert res.status_code == 400
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # check that the returned self link returns the same data
+#             subtest_self_link(response_data, headers, client)
 
 
-@community_with_and_without_access_control
-def test_valid_put(app, login_user,
-                   communities_permissions):
-    """Test VALID community put request (PUT .../communities/<id>)."""
-    with app.app_context():
-        # create community
-        created_community = Community.create_community(**community_metadata)
-        community_id = created_community.id
-        # create allowed user
-        allowed_user = create_user('allowed')
-        communities_permissions(
-            allowed_user.id).update_permission(True, community_id)
-        communities_permissions(
-            allowed_user.id).read_permission(True, community_id)
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_invalid_patch(app, login_user,
+#                        communities_permissions):
+#     """Test INVALID community patch request (PATCH .../communities/<id>)."""
+#     with app.app_context():
+#         # create user allowed to update all records
+#         allowed_user = create_user('allowed')
+#         communities_permissions(
+#             allowed_user.id).update_permission(True, None)
+#         db.session.commit()
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             unknown_uuid = uuid.uuid4()
+#             # check that PATCH with non existing id will return 404
+#             headers = [('Content-Type', 'application/json-patch+json'),
+#                        ('Accept', 'application/json')]
+#             res = client.patch(url_for('b2share_communities.communities_item',
+#                                        community_id=unknown_uuid),
+#                                data=json.dumps(community_patch),
+#                                headers=headers)
+#             assert res.status_code == 404
 
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(url_for('b2share_communities.communities_item',
-                                     community_id=community_id),
-                             data=json.dumps(patched_community_metadata),
-                             headers=headers)
-            assert res.status_code == 200
-            # check that the returned community matches the given data
-            response_data = json.loads(res.get_data(as_text=True))
-            for field, value in patched_community_metadata.items():
-                assert response_data[field] == value
+#             # create community
+#             created_community = Community.create_community(
+#                 **community_metadata)
+#             community_id = created_community.id
+#             db.session.commit()
 
-            # check that an internal community returned id and that it contains
-            # the same data
-            assert 'id' in response_data.keys()
-            assert response_data['id'] == str(Community.get(
-                name=patched_community_metadata['name']).id)
-            headers = res.headers
+#             # check that PATCH with non accepted format will return 406
+#             headers = [('Content-Type', 'application/json-patch+json'),
+#                        ('Accept', 'video/mp4')]
+#             res = client.patch(url_for('b2share_communities.communities_item',
+#                                        community_id=community_id),
+#                                data=json.dumps(community_patch),
+#                                headers=headers)
+#             assert res.status_code == 406
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            # check that the returned self link returns the same data
-            subtest_self_link(response_data, headers, client)
+#             # check that PATCH with non-json Content-Type will return 415
+#             headers = [('Content-Type', 'video/mp4'),
+#                        ('Accept', 'application/json')]
+#             res = client.patch(url_for('b2share_communities.communities_item',
+#                                        community_id=community_id),
+#                                data=json.dumps(community_patch),
+#                                headers=headers)
+#             assert res.status_code == 415
 
+#             # check that PATCH with invalid json-patch will return 400
+#             headers = [('Content-Type', 'application/json-patch+json'),
+#                        ('Accept', 'application/json')]
+#             res = client.patch(url_for('b2share_communities.communities_item',
+#                                        community_id=community_id),
+#                                data=json.dumps([
+#                                    {'invalid': 'json-patch'}
+#                                ]),
+#                                headers=headers)
+#             assert res.status_code == 400
 
-@community_with_and_without_access_control
-def test_invalid_put(app, login_user,
-                     communities_permissions):
-    """Test INVALID community put request (PUT .../communities/<id>)."""
-    with app.app_context():
-        # create allowed user
-        allowed_user = create_user('allowed')
-        communities_permissions(
-            allowed_user.id).update_permission(True, None)
-        db.session.commit()
-
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            unknown_uuid = uuid.uuid4()
-            # check that PUT with non existing id will return 404
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(url_for('b2share_communities.communities_item',
-                                     community_id=unknown_uuid),
-                             data=json.dumps(patched_community_metadata),
-                             headers=headers)
-            assert res.status_code == 404
-
-            # create community
-            created_community = Community.create_community(
-                **community_metadata)
-            community_id = created_community.id
-            db.session.commit()
-
-            # check that PUT with non accepted format will return 406
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'video/mp4')]
-            res = client.put(url_for('b2share_communities.communities_item',
-                                     community_id=community_id),
-                             data=json.dumps(patched_community_metadata),
-                             headers=headers)
-            assert res.status_code == 406
-
-            # check that PUT with non-json Content-Type will return 415
-            headers = [('Content-Type', 'video/mp4'),
-                       ('Accept', 'application/json')]
-            res = client.put(url_for('b2share_communities.communities_item',
-                                     community_id=community_id),
-                             data=json.dumps(patched_community_metadata),
-                             headers=headers)
-            assert res.status_code == 415
-
-            # check that PUT with invalid json will return 400
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(url_for('b2share_communities.communities_item',
-                                     community_id=community_id),
-                             data='{invalid-json',
-                             headers=headers)
-            assert res.status_code == 400
+#             # check that PATCH with invalid json will return 400
+#             headers = [('Content-Type', 'application/json-patch+json'),
+#                        ('Accept', 'application/json')]
+#             res = client.patch(url_for('b2share_communities.communities_item',
+#                                        community_id=community_id),
+#                                data='{sdfsdf',
+#                                headers=headers)
+#             assert res.status_code == 400
 
 
-@community_with_and_without_access_control
-def test_valid_delete(app, login_user,
-                      communities_permissions):
-    """Test VALID community delete request (DELETE .../communities/<id>)."""
-    with app.app_context():
-        # create community
-        created_community = Community.create_community(**community_metadata)
-        community_id = created_community.id
-        # create allowed user
-        allowed_user = create_user('allowed')
-        communities_permissions(
-            allowed_user.id).delete_permission(True, community_id)
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_valid_put(app, login_user,
+#                    communities_permissions):
+#     """Test VALID community put request (PUT .../communities/<id>)."""
+#     with app.app_context():
+#         # create community
+#         created_community = Community.create_community(**community_metadata)
+#         community_id = created_community.id
+#         # create allowed user
+#         allowed_user = create_user('allowed')
+#         communities_permissions(
+#             allowed_user.id).update_permission(True, community_id)
+#         communities_permissions(
+#             allowed_user.id).read_permission(True, community_id)
+#         db.session.commit()
 
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.delete(url_for('b2share_communities.communities_item',
-                                        community_id=community_id),
-                                headers=headers)
-            assert res.status_code == 204
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
 
-    with app.app_context():
-        # check database state
-        with pytest.raises(CommunityDeletedError):
-            Community.get(community_id)
-        community = Community.get(community_id, with_deleted=True)
-        assert community.deleted
-        # check that one community has been created
-        assert len(CommunityModel.query.all()) == 1
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(url_for('b2share_communities.communities_item',
+#                                      community_id=community_id),
+#                              data=json.dumps(patched_community_metadata),
+#                              headers=headers)
+#             assert res.status_code == 200
+#             # check that the returned community matches the given data
+#             response_data = json.loads(res.get_data(as_text=True))
+#             for field, value in patched_community_metadata.items():
+#                 assert response_data[field] == value
 
+#             # check that an internal community returned id and that it contains
+#             # the same data
+#             assert 'id' in response_data.keys()
+#             assert response_data['id'] == str(Community.get(
+#                 name=patched_community_metadata['name']).id)
+#             headers = res.headers
 
-@community_with_and_without_access_control
-def test_invalid_delete(app, login_user,
-                        communities_permissions):
-    """Test INVALID community delete request (DELETE .../communities/<id>)."""
-    with app.app_context():
-        # create allowed user
-        allowed_user = create_user('allowed')
-        communities_permissions(
-            allowed_user.id).delete_permission(True, None)
-        db.session.commit()
-
-        with app.test_client() as client:
-            login_user(allowed_user, client)
-            unknown_uuid = uuid.uuid4()
-            # check that GET with non existing id will return 404
-            headers = [('Accept', 'application/json')]
-            res = client.delete(url_for('b2share_communities.communities_item',
-                                        community_id=unknown_uuid),
-                                headers=headers)
-            assert res.status_code == 404
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             # check that the returned self link returns the same data
+#             subtest_self_link(response_data, headers, client)
 
 
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_invalid_put(app, login_user,
+#                      communities_permissions):
+#     """Test INVALID community put request (PUT .../communities/<id>)."""
+#     with app.app_context():
+#         # create allowed user
+#         allowed_user = create_user('allowed')
+#         communities_permissions(
+#             allowed_user.id).update_permission(True, None)
+#         db.session.commit()
+
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             unknown_uuid = uuid.uuid4()
+#             # check that PUT with non existing id will return 404
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(url_for('b2share_communities.communities_item',
+#                                      community_id=unknown_uuid),
+#                              data=json.dumps(patched_community_metadata),
+#                              headers=headers)
+#             assert res.status_code == 404
+
+#             # create community
+#             created_community = Community.create_community(
+#                 **community_metadata)
+#             community_id = created_community.id
+#             db.session.commit()
+
+#             # check that PUT with non accepted format will return 406
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'video/mp4')]
+#             res = client.put(url_for('b2share_communities.communities_item',
+#                                      community_id=community_id),
+#                              data=json.dumps(patched_community_metadata),
+#                              headers=headers)
+#             assert res.status_code == 406
+
+#             # check that PUT with non-json Content-Type will return 415
+#             headers = [('Content-Type', 'video/mp4'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(url_for('b2share_communities.communities_item',
+#                                      community_id=community_id),
+#                              data=json.dumps(patched_community_metadata),
+#                              headers=headers)
+#             assert res.status_code == 415
+
+#             # check that PUT with invalid json will return 400
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(url_for('b2share_communities.communities_item',
+#                                      community_id=community_id),
+#                              data='{invalid-json',
+#                              headers=headers)
+#             assert res.status_code == 400
+
+
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_valid_delete(app, login_user,
+#                       communities_permissions):
+#     """Test VALID community delete request (DELETE .../communities/<id>)."""
+#     with app.app_context():
+#         # create community
+#         created_community = Community.create_community(**community_metadata)
+#         community_id = created_community.id
+#         # create allowed user
+#         allowed_user = create_user('allowed')
+#         communities_permissions(
+#             allowed_user.id).delete_permission(True, community_id)
+#         db.session.commit()
+
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.delete(url_for('b2share_communities.communities_item',
+#                                         community_id=community_id),
+#                                 headers=headers)
+#             assert res.status_code == 204
+
+#     with app.app_context():
+#         # check database state
+#         with pytest.raises(CommunityDeletedError):
+#             Community.get(community_id)
+#         community = Community.get(community_id, with_deleted=True)
+#         assert community.deleted
+#         # check that one community has been created
+#         assert len(CommunityModel.query.all()) == 1
+
+
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @community_with_and_without_access_control
+# def test_invalid_delete(app, login_user,
+#                         communities_permissions):
+#     """Test INVALID community delete request (DELETE .../communities/<id>)."""
+#     with app.app_context():
+#         # create allowed user
+#         allowed_user = create_user('allowed')
+#         communities_permissions(
+#             allowed_user.id).delete_permission(True, None)
+#         db.session.commit()
+
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
+#             unknown_uuid = uuid.uuid4()
+#             # check that GET with non existing id will return 404
+#             headers = [('Accept', 'application/json')]
+#             res = client.delete(url_for('b2share_communities.communities_item',
+#                                         community_id=unknown_uuid),
+#                                 headers=headers)
+#             assert res.status_code == 404
+
+
+# FIXME: Test is disabled for V2 as it is not used by the UI
 @community_with_and_without_access_control
 def test_action_on_deleted(app, login_user,
                            communities_permissions):
@@ -545,13 +554,13 @@ def test_action_on_deleted(app, login_user,
         Community.get(community_id).delete()
         with app.test_client() as client:
             login_user(allowed_user, client)
-            # try DELETE
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.delete(url_for('b2share_communities.communities_item',
-                                        community_id=community_id),
-                                headers=headers)
-            assert_410_gone_result(res)
+#             # try DELETE
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.delete(url_for('b2share_communities.communities_item',
+#                                         community_id=community_id),
+#                                 headers=headers)
+#             assert_410_gone_result(res)
             # try GET
             headers = [('Content-Type', 'application/json'),
                        ('Accept', 'application/json')]
@@ -559,22 +568,22 @@ def test_action_on_deleted(app, login_user,
                                      community_id=community_id),
                              headers=headers)
             assert_410_gone_result(res)
-            # try PUT
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(url_for('b2share_communities.communities_item',
-                                     community_id=community_id),
-                             data=json.dumps(patched_community_metadata),
-                             headers=headers)
-            assert_410_gone_result(res)
-            # try PATCH
-            headers = [('Content-Type', 'application/json-patch+json'),
-                       ('Accept', 'application/json')]
-            res = client.patch(url_for('b2share_communities.communities_item',
-                                       community_id=community_id),
-                               data=json.dumps(community_patch),
-                               headers=headers)
-            assert_410_gone_result(res)
+#             # try PUT
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(url_for('b2share_communities.communities_item',
+#                                      community_id=community_id),
+#                              data=json.dumps(patched_community_metadata),
+#                              headers=headers)
+#             assert_410_gone_result(res)
+#             # try PATCH
+#             headers = [('Content-Type', 'application/json-patch+json'),
+#                        ('Accept', 'application/json')]
+#             res = client.patch(url_for('b2share_communities.communities_item',
+#                                        community_id=community_id),
+#                                data=json.dumps(community_patch),
+#                                headers=headers)
+#             assert_410_gone_result(res)
 
     # check that the record exist and is marked as deleted
     with app.app_context():

--- a/tests/b2share_unit_tests/communities/test_communities_rest_permissions.py
+++ b/tests/b2share_unit_tests/communities/test_communities_rest_permissions.py
@@ -35,97 +35,100 @@ from b2share.modules.communities.models import Community as CommunityModel
 from b2share_unit_tests.helpers import create_user
 
 
-@pytest.mark.parametrize('app', [({
-    'extensions': [B2ShareCommunities],
-    'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': False}
-})],
-    indirect=['app'])
-def test_create_access_control(app, login_user, communities_permissions):
-    """Test community creation with differnet access rights."""
-    with app.app_context():
-        allowed_user = create_user('allowed')
-        not_allowed_user = create_user('not allowed')
-        communities_permissions(allowed_user.id).create_permission(True)
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @pytest.mark.parametrize('app', [({
+#     'extensions': [B2ShareCommunities],
+#     'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': False}
+# })],
+#     indirect=['app'])
+# def test_create_access_control(app, login_user, communities_permissions):
+#     """Test community creation with differnet access rights."""
+#     with app.app_context():
+#         allowed_user = create_user('allowed')
+#         not_allowed_user = create_user('not allowed')
+#         communities_permissions(allowed_user.id).create_permission(True)
+#         db.session.commit()
 
-    # test without login
-    with app.app_context():
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 401
-        assert len(CommunityModel.query.all()) == 0
+#     # test without login
+#     with app.app_context():
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 401
+#         assert len(CommunityModel.query.all()) == 0
 
-    # test not allowed user
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(not_allowed_user, client)
+#     # test not allowed user
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(not_allowed_user, client)
 
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 403
-        assert len(CommunityModel.query.all()) == 0
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 403
+#         assert len(CommunityModel.query.all()) == 0
 
-    # test allowed user
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(allowed_user, client)
+#     # test allowed user
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(allowed_user, client)
 
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 201
-        assert len(CommunityModel.query.all()) == 1
-
-
-@pytest.mark.parametrize('app', [({
-    'extensions': [B2ShareCommunities],
-    'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
-})],
-    indirect=['app'])
-def test_create_unlogged_disabled_access_control(app, login_user,
-                                                 communities_permissions):
-    """Test community creation with ACL disabled and unlogged user."""
-    with app.app_context():
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 201
-        assert len(CommunityModel.query.all()) == 1
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 201
+#         assert len(CommunityModel.query.all()) == 1
 
 
-@pytest.mark.parametrize('app', [({
-    'extensions': [B2ShareCommunities],
-    'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
-})],
-    indirect=['app'])
-def test_create_not_allowed_disabled_access_control(app, login_user,
-                                                    communities_permissions):
-    """Test community creation with ACL disabled and not allowed user."""
-    with app.app_context():
-        not_allowed_user = create_user('not allowed')
-        db.session.commit()
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @pytest.mark.parametrize('app', [({
+#     'extensions': [B2ShareCommunities],
+#     'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
+# })],
+#     indirect=['app'])
+# def test_create_unlogged_disabled_access_control(app, login_user,
+#                                                  communities_permissions):
+#     """Test community creation with ACL disabled and unlogged user."""
+#     with app.app_context():
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 201
+#         assert len(CommunityModel.query.all()) == 1
 
-    # test not allowed user
-    with app.app_context():
-        with app.test_client() as client:
-            login_user(not_allowed_user, client)
 
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(url_for('b2share_communities.communities_list'),
-                              data=json.dumps(community_metadata),
-                              headers=headers)
-            assert res.status_code == 201
-        assert len(CommunityModel.query.all()) == 1
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# @pytest.mark.parametrize('app', [({
+#     'extensions': [B2ShareCommunities],
+#     'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
+# })],
+#     indirect=['app'])
+# def test_create_not_allowed_disabled_access_control(app, login_user,
+#                                                     communities_permissions):
+#     """Test community creation with ACL disabled and not allowed user."""
+#     with app.app_context():
+#         not_allowed_user = create_user('not allowed')
+#         db.session.commit()
+
+#     # test not allowed user
+#     with app.app_context():
+#         with app.test_client() as client:
+#             login_user(not_allowed_user, client)
+
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(url_for('b2share_communities.communities_list'),
+#                               data=json.dumps(community_metadata),
+#                               headers=headers)
+#             assert res.status_code == 201
+#         assert len(CommunityModel.query.all()) == 1

--- a/tests/b2share_unit_tests/schemas/test_schemas_rest.py
+++ b/tests/b2share_unit_tests/schemas/test_schemas_rest.py
@@ -73,101 +73,104 @@ def test_valid_get_community_schema(app, test_communities):
             # check that the returned self link returns the same data
             subtest_self_link(response_data, res.headers, client)
 
-
-def test_create_block_schema(app, test_communities):
-    """Test creating a new schema."""
-    with app.app_context():
-        community_id = str(test_communities['MyTestCommunity1'])
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.post(
-                url_for(
-                    'b2share_schemas.block_schema_list'
-                ),
-                data=json.dumps({
-                    'name': 'abc',
-                    'community_id': community_id,
-                }),
-                headers=headers)
-            assert res.status_code == 201
-            response_data = json.loads(res.get_data(as_text=True))
-            assert response_data['name'] == BlockSchema.get_block_schema(
-                                                response_data['schema_id']
-                                            ).name
-            assert str(
-                BlockSchema.get_block_schema(response_data['schema_id'])
-                    .community
-            ) == community_id
-
-
-def test_create_block_schema_version(app, test_communities):
-    """Test creating a new version of the schema."""
-    with app.app_context():
-        community_id = str(test_communities['MyTestCommunity1'])
-        json_schema = block_schemas_json_schemas[0][0]
-        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(
-                url_for(
-                    'b2share_schemas.block_schema_versions_item',
-                    schema_id=str(block_schema.id),
-                    schema_version_nb=0
-                ),
-                data=json.dumps({
-                    'json_schema': json_schema
-                }),
-                headers=headers)
-            assert res.status_code == 201
-            response_data = json.loads(res.get_data(as_text=True))
-            assert response_data['json_schema'] == json_schema
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# def test_create_block_schema(app, test_communities):
+#     """Test creating a new schema."""
+#     with app.app_context():
+#         community_id = str(test_communities['MyTestCommunity1'])
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.post(
+#                 url_for(
+#                     'b2share_schemas.block_schema_list'
+#                 ),
+#                 data=json.dumps({
+#                     'name': 'abc',
+#                     'community_id': community_id,
+#                 }),
+#                 headers=headers)
+#             assert res.status_code == 201
+#             response_data = json.loads(res.get_data(as_text=True))
+#             assert response_data['name'] == BlockSchema.get_block_schema(
+#                                                 response_data['schema_id']
+#                                             ).name
+#             assert str(
+#                 BlockSchema.get_block_schema(response_data['schema_id'])
+#                     .community
+#             ) == community_id
 
 
-def test_create_existing_block_schema_version(app, test_communities):
-    """Test creating an axisting version of the schema."""
-    with app.app_context():
-        community_id = str(test_communities['MyTestCommunity1'])
-        json_schema = block_schemas_json_schemas[0][0]
-        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
-        all_versions = block_schema.versions
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(
-                url_for(
-                    'b2share_schemas.block_schema_versions_item',
-                    schema_id=str(block_schema.id),
-                    schema_version_nb=len(all_versions) - 1
-                ),
-                data=json.dumps({
-                    'json_schema': json_schema
-                }),
-                headers=headers)
-            assert res.status_code == 409
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# def test_create_block_schema_version(app, test_communities):
+#     """Test creating a new version of the schema."""
+#     with app.app_context():
+#         community_id = str(test_communities['MyTestCommunity1'])
+#         json_schema = block_schemas_json_schemas[0][0]
+#         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(
+#                 url_for(
+#                     'b2share_schemas.block_schema_versions_item',
+#                     schema_id=str(block_schema.id),
+#                     schema_version_nb=0
+#                 ),
+#                 data=json.dumps({
+#                     'json_schema': json_schema
+#                 }),
+#                 headers=headers)
+#             assert res.status_code == 201
+#             response_data = json.loads(res.get_data(as_text=True))
+#             assert response_data['json_schema'] == json_schema
 
 
-def test_create_invalid_block_schema_version(app, test_communities):
-    """Test creating an invalid version of the schema."""
-    with app.app_context():
-        community_id = str(test_communities['MyTestCommunity1'])
-        json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
-        block_schema = BlockSchema.create_block_schema(community_id, 'abc')
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.put(
-                url_for(
-                    'b2share_schemas.block_schema_versions_item',
-                    schema_id=str(block_schema.id),
-                    schema_version_nb=5
-                ),
-                data=json.dumps({
-                    'json_schema': json_schema
-                }),
-                headers=headers)
-            assert res.status_code == 400
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# def test_create_existing_block_schema_version(app, test_communities):
+#     """Test creating an axisting version of the schema."""
+#     with app.app_context():
+#         community_id = str(test_communities['MyTestCommunity1'])
+#         json_schema = block_schemas_json_schemas[0][0]
+#         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+#         all_versions = block_schema.versions
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(
+#                 url_for(
+#                     'b2share_schemas.block_schema_versions_item',
+#                     schema_id=str(block_schema.id),
+#                     schema_version_nb=len(all_versions) - 1
+#                 ),
+#                 data=json.dumps({
+#                     'json_schema': json_schema
+#                 }),
+#                 headers=headers)
+#             assert res.status_code == 409
+
+
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# def test_create_invalid_block_schema_version(app, test_communities):
+#     """Test creating an invalid version of the schema."""
+#     with app.app_context():
+#         community_id = str(test_communities['MyTestCommunity1'])
+#         json_schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
+#         block_schema = BlockSchema.create_block_schema(community_id, 'abc')
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.put(
+#                 url_for(
+#                     'b2share_schemas.block_schema_versions_item',
+#                     schema_id=str(block_schema.id),
+#                     schema_version_nb=5
+#                 ),
+#                 data=json.dumps({
+#                     'json_schema': json_schema
+#                 }),
+#                 headers=headers)
+#             assert res.status_code == 400
 
 
 def test_get_block_schema_version(app, test_communities):
@@ -231,22 +234,23 @@ def test_get_block_schemas(app, test_communities):
             assert response_data['schemas'][1]['name'] == block_schema_3.name
 
 
-def test_updating_block_schema(app, test_communities):
-    """Test updating a block schema."""
-    with app.app_context():
-        community = Community.create_community('name1', 'desc1')
-        community_id = community.id
-        block_schema = BlockSchema.create_block_schema(community_id, 'original')
-        with app.test_client() as client:
-            headers = [('Content-Type', 'application/json'),
-                       ('Accept', 'application/json')]
-            res = client.patch(
-                url_for(
-                    'b2share_schemas.block_schema_item',
-                    schema_id=block_schema.id
-                ),
-                data=json.dumps({
-                    'name': 'abc'
-                }),
-                headers=headers)
-            assert res.status_code == 200
+# FIXME: Test is disabled for V2 as it is not used by the UI
+# def test_updating_block_schema(app, test_communities):
+#     """Test updating a block schema."""
+#     with app.app_context():
+#         community = Community.create_community('name1', 'desc1')
+#         community_id = community.id
+#         block_schema = BlockSchema.create_block_schema(community_id, 'original')
+#         with app.test_client() as client:
+#             headers = [('Content-Type', 'application/json'),
+#                        ('Accept', 'application/json')]
+#             res = client.patch(
+#                 url_for(
+#                     'b2share_schemas.block_schema_item',
+#                     schema_id=block_schema.id
+#                 ),
+#                 data=json.dumps({
+#                     'name': 'abc'
+#                 }),
+#                 headers=headers)
+#             assert res.status_code == 200


### PR DESCRIPTION
* Disables REST endpoints which are not used by the UI before
  B2SHARE v2.0.0 release. This prevents any unnecessary security
  breach.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>