### PR TITLE
views: flask-security endpoints disabled

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -186,8 +186,8 @@ OAUTHCLIENT_REMOTE_APPS = dict(
     b2access=b2access.REMOTE_APP,
 )
 
-# Let Invenio Accounts register Flask Security
-ACCOUNTS_REGISTER_BLUEPRINT = True
+# Don't let Invenio Accounts register Flask Security
+ACCOUNTS_REGISTER_BLUEPRINT = False
 
 
 ACCOUNTS_REST_ASSIGN_ROLE_PERMISSION_FACTORY = \

--- a/b2share/modules/users/views.py
+++ b/b2share/modules/users/views.py
@@ -28,6 +28,7 @@ from invenio_db import db
 from invenio_rest import ContentNegotiatedMethodView
 from invenio_oauth2server import current_oauth2server
 from invenio_oauth2server.models import Token
+from flask_security.views import logout
 
 from .serializers import (user_to_json_serializer,
                           token_to_json_serializer,
@@ -135,3 +136,5 @@ class UserToken(ContentNegotiatedMethodView):
 blueprint.add_url_rule('/', view_func=CurrentUser.as_view('current_user'))
 blueprint.add_url_rule('/tokens', view_func=UserTokenList.as_view('user_token_list'))
 blueprint.add_url_rule('/tokens/<token_id>', view_func=UserToken.as_view('user_token_item'))
+# register the flask_security logout endpoint
+blueprint.route('/logout/', endpoint='logout')(logout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,8 @@ def app(request, tmpdir):
         WTF_CSRF_ENABLED=False,
         SECRET_KEY="CHANGE_ME",
         SECURITY_PASSWORD_SALT='CHANGEME',
+        # register flask_security endpoints for testing purpose.
+        ACCOUNTS_REGISTER_BLUEPRINT = True,
         CELERY_ALWAYS_EAGER=True,
         CELERY_RESULT_BACKEND="cache",
         CELERY_CACHE_BACKEND="memory",

--- a/webui/src/components/user.jsx
+++ b/webui/src/components/user.jsx
@@ -48,7 +48,7 @@ export const NavbarUser = React.createClass({
                 <ul className="dropdown-menu pull-right" role="menu">
                     <li><Link to="/user"> <i className="fa fa-info"></i> Profile </Link></li>
                     <li className="divider"></li>
-                    <li><a href="/api/logout/"> <i className="glyphicon glyphicon-log-out"></i> Logout </a></li>
+                    <li><a href="/api/user/logout/"> <i className="glyphicon glyphicon-log-out"></i> Logout </a></li>
                 </ul>
             </li>
         );


### PR DESCRIPTION
* Disables flask-security endpoints as most of them were not used.
  Moves the logout endpoint to '/api/user/logout/'. (closes #1397)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>