### PR TITLE
models: direct_publish as default deposit workflow

### DIFF
--- a/b2share/modules/communities/models.py
+++ b/b2share/modules/communities/models.py
@@ -69,7 +69,7 @@ class Community(db.Model, Timestamp):
 
     # Publication workflow used in this community
     publication_workflow = db.Column(db.String(80), nullable=False,
-                                     default='review_and_publish')
+                                     default='direct_publish')
 
     # Restrict record creation
     restricted_submission = db.Column(db.Boolean, nullable=False,


### PR DESCRIPTION
* Changes default deposit workflow to "direct_publish" as the UI
  does not yet support records reviews. (closes #1403)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>