### PR TITLE
rabbitmq and port hardening

### DIFF
--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "B2SHARE_CACHE_REDIS_HOST='redis'"
             - "B2SHARE_CACHE_REDIS_URL='redis://redis:6379/0'"
             - "B2SHARE_ACCOUNTS_SESSION_REDIS_URL='redis://redis:6379/1'"
-            - "B2SHARE_BROKER_URL='amqp://guest:guest@mq:5672//'"
+            - "B2SHARE_BROKER_URL='amqp://${B2SHARE_RABBIT_USER}:${B2SHARE_RABBIT_PASSWORD}@mq:5672//'"
             - "B2SHARE_CELERY_RESULT_BACKEND='redis://redis:6379/2'"
             - "B2SHARE_SEARCH_ELASTIC_HOSTS='elasticsearch'"
         volumes:
@@ -66,15 +66,15 @@ services:
             - b2share
 
     mq:
+        hostname: b2share-redis
         image: rabbitmq:3.6-management
         restart: "always"
         ports:
             - "15672"
             - "5672"
-        read_only: true
+#        read_only: true
         volumes:
             - "${B2SHARE_DATADIR}/rabbitmq-data:/var/lib/rabbitmq"
-        entrypoint:
-            - "rabbitmq-server"
-            - "--hostname"
-            - "b2share-redis"
+        environment:
+            - "RABBITMQ_DEFAULT_USER=${B2SHARE_RABBIT_USER}"
+            - "RABBITMQ_DEFAULT_PASS=${B2SHARE_RABBIT_PASSWORD}"

--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -8,8 +8,8 @@ services:
             - "PGDATA=/var/lib/postgresql/data"
         volumes:
             - "${B2SHARE_DATADIR}/postgres-data:/var/lib/postgresql/data"
-        ports:
-            - "5432"
+#        ports:
+#            - "5432"
 
     b2share:
         build:
@@ -33,8 +33,8 @@ services:
             - "B2SHARE_SEARCH_ELASTIC_HOSTS='elasticsearch'"
         volumes:
             - "${B2SHARE_DATADIR}/b2share-data:/usr/var/b2share-instance"
-        ports:
-            - "5000"
+#        ports:
+#            - "5000"
         links:
             - elasticsearch
             - redis
@@ -42,16 +42,16 @@ services:
 
     elasticsearch:
         build: elasticsearch
-        ports:
-            - "9200"
-            - "9300"
+#        ports:
+#            - "9200"
+#            - "9300"
         volumes:
             - "${B2SHARE_DATADIR}/elasticsearch-data:/usr/share/elasticsearch/data"
 
     redis:
         image: redis:3.2-alpine
-        ports:
-            - "6379"
+#        ports:
+#            - "6379"
         volumes:
             - "${B2SHARE_DATADIR}/redis-data:/data"
 
@@ -69,9 +69,9 @@ services:
         hostname: b2share-redis
         image: rabbitmq:3.6-management-alpine
         restart: "always"
-        ports:
-            - "15672"
-            - "5672"
+#        ports:
+#            - "15672"
+#            - "5672"
 #        read_only: true
         volumes:
             - "${B2SHARE_DATADIR}/rabbitmq-data:/var/lib/rabbitmq"

--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -49,7 +49,7 @@ services:
             - "${B2SHARE_DATADIR}/elasticsearch-data:/usr/share/elasticsearch/data"
 
     redis:
-        image: redis:3.2
+        image: redis:3.2-alpine
         ports:
             - "6379"
         volumes:
@@ -67,7 +67,7 @@ services:
 
     mq:
         hostname: b2share-redis
-        image: rabbitmq:3.6-management
+        image: rabbitmq:3.6-management-alpine
         restart: "always"
         ports:
             - "15672"


### PR DESCRIPTION
This PR addresses #1423 but also introduces the configuration of rabbitmq username/password. And, it should be possible to use alpine images for rabbitmq/redis.
