### PR TITLE
cli: new b2records cli command for expired embargoes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,6 +26,7 @@ Authors
 - Adrian Mouat (KTH)
 - Carl Johan Håkansson (KTH)
 - Dennis Blommensteijn (SURFsara)
+- Dinos Kousidis (CERN)
 - Emanuel Dima (EKUT)
 - Hilary Hanahoe (TRUST)
 - Huw Morris (STFC)

--- a/b2share/config.py
+++ b/b2share/config.py
@@ -261,7 +261,7 @@ CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 #: Beat schedule
 CELERYBEAT_SCHEDULE = {
     'embargo-updater': {
-        'task': 'b2share.modules.records.tasks.update_expired_embargos',
+        'task': 'b2share.modules.records.tasks.update_expired_embargoes',
         'schedule': crontab(minute=2, hour=0),
     },
     'indexer': {

--- a/b2share/modules/records/cli.py
+++ b/b2share/modules/records/cli.py
@@ -36,6 +36,7 @@ from invenio_pidstore.providers.datacite import DataCiteProvider
 from b2share.modules.records.serializers import datacite_v31
 from b2share.modules.records.minters import make_record_url
 from b2share.modules.communities.api import Community
+from b2share.modules.records.tasks import update_expired_embargos
 from .utils import list_db_published_records
 
 
@@ -52,6 +53,14 @@ def check_dois(update):
     """
     for record in list_db_published_records():
         check_record_doi(record, update)
+
+
+@b2records.command()
+@with_appcontext
+def update_expired_embargoes():
+    """Updates all records with expired embargoes to open access."""
+    update_expired_embargos.delay()
+    click.secho('Expiring embargoes...', fg='green')
 
 
 def check_record_doi(record, update=False):

--- a/b2share/modules/records/cli.py
+++ b/b2share/modules/records/cli.py
@@ -36,7 +36,8 @@ from invenio_pidstore.providers.datacite import DataCiteProvider
 from b2share.modules.records.serializers import datacite_v31
 from b2share.modules.records.minters import make_record_url
 from b2share.modules.communities.api import Community
-from b2share.modules.records.tasks import update_expired_embargos
+from b2share.modules.records.tasks import update_expired_embargoes \
+    as update_expired_embargoes_task
 from .utils import list_db_published_records
 
 
@@ -59,7 +60,7 @@ def check_dois(update):
 @with_appcontext
 def update_expired_embargoes():
     """Updates all records with expired embargoes to open access."""
-    update_expired_embargos.delay()
+    update_expired_embargoes_task.delay()
     click.secho('Expiring embargoes...', fg='green')
 
 

--- a/b2share/modules/records/tasks.py
+++ b/b2share/modules/records/tasks.py
@@ -39,7 +39,7 @@ from .search import B2ShareRecordsSearch
 
 
 @shared_task(ignore_result=True)
-def update_expired_embargos():
+def update_expired_embargoes():
     """Release expired embargoes every midnight."""
     logger = current_app.logger
     base_url = urlunsplit((

--- a/tests/b2share_unit_tests/records/test_records_tasks.py
+++ b/tests/b2share_unit_tests/records/test_records_tasks.py
@@ -30,7 +30,7 @@ from b2share_unit_tests.helpers import (
     create_record, generate_record_data, subtest_file_bucket_permissions,
     create_user,
 )
-from b2share.modules.records.tasks import update_expired_embargos
+from b2share.modules.records.tasks import update_expired_embargoes
 # from invenio_records_files.api import Record
 from invenio_db import db
 from invenio_search import current_search
@@ -98,7 +98,7 @@ def test_update_expired_embargo(app, test_communities, login_user, cli_cmd):
 
     with app.app_context():
         if not cli_cmd:
-            update_expired_embargos.delay()
+            update_expired_embargoes.delay()
         else:
             script_info = ScriptInfo(create_app=lambda info: app)
             runner = CliRunner()


### PR DESCRIPTION
* NEW Adds command line interface command to update
  expired embargoes. (closes #1405)

* Updates the AUTHORS.rst file.

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>