### PR TITLE
tests: improve tests speed

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -58,10 +58,6 @@ BABEL_DEFAULT_TIMEZONE = 'Europe/Zurich'
 I18N_LANGUAGES = [
 ]
 
-# FIXME disable authentication by default as B2Access integration is not yet
-# done.
-B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED = False
-
 # Records
 # =======
 

--- a/b2share/modules/communities/ext.py
+++ b/b2share/modules/communities/ext.py
@@ -39,21 +39,6 @@ class _B2ShareCommunitiesState(object):
             app: the Flask application.
         """
         self.app = app
-        self._rest_access_control_disabled = None
-
-    @cached_property
-    def rest_access_control_disabled(self):
-        """Load the REST API access control disabling flag from app config.
-
-        Returns:
-            bool: True if B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED is
-                set to True in the application configuration, else False.
-        """
-        if self._rest_access_control_disabled is None:
-            self._rest_access_control_disabled = self.app.config.get(
-                'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED')
-        return (self._rest_access_control_disabled if
-                self._rest_access_control_disabled is not None else False)
 
 
 class B2ShareCommunities(object):

--- a/b2share/modules/communities/views.py
+++ b/b2share/modules/communities/views.py
@@ -97,8 +97,7 @@ def need_community_permission(permission_factory):
         @wraps(f)
         def need_community_permission_decorator(self, community, *args,
                                                 **kwargs):
-            if not current_communities.rest_access_control_disabled:
-                verify_community_permission(permission_factory, community)
+            verify_community_permission(permission_factory, community)
             return f(self, community=community, *args, **kwargs)
         return need_community_permission_decorator
     return need_community_permission_builder

--- a/tests/b2share_functional_tests/test_schema_cli.py
+++ b/tests/b2share_functional_tests/test_schema_cli.py
@@ -59,10 +59,6 @@ test_schema = {
     "required": ["test_field1"]
 }
 
-configurations = [({'config': {'PREFERRED_URL_SCHEME': 'https'}}),
-                  ({'config': {'PREFERRED_URL_SCHEME': 'http'}})]
-
-@pytest.mark.parametrize('app', configurations, indirect=['app'])
 def test_existing_community_set_schema_cmd(app, test_communities):
     """Test the `schemas set_schema` CLI command."""
     with app.app_context():
@@ -88,7 +84,6 @@ def test_existing_community_set_schema_cmd(app, test_communities):
             assert result.exit_code == 0
 
 
-@pytest.mark.parametrize('app', configurations, indirect=['app'])
 def test_new_community_set_schema_cmd(app, login_user, tmp_location):
     """Test adding a community and setting its schema using CLI commands."""
     with app.app_context():

--- a/tests/b2share_unit_tests/communities/conftest.py
+++ b/tests/b2share_unit_tests/communities/conftest.py
@@ -45,44 +45,36 @@ def communities_permissions(app):
             with db.session.begin_nested():
                 user = accounts.datastore.get_user(self.user_id)
                 # only add the access rights if the access control is enabled
-                if not app.extensions[
-                        'b2share-communities'].rest_access_control_disabled:
-                    db.session.add(ActionUsers(
-                        action=communities_create_all.value, argument=None,
-                        user=user, exclude=not allow))
+                db.session.add(ActionUsers(
+                    action=communities_create_all.value, argument=None,
+                    user=user, exclude=not allow))
 
         def read_permission(self, allow, community_id=None):
             with db.session.begin_nested():
                 user = accounts.datastore.get_user(self.user_id)
                 # only add the access rights if the access control is enabled
-                if not app.extensions[
-                        'b2share-communities'].rest_access_control_disabled:
-                    db.session.add(ActionUsers(
-                        action=communities_read_all.value,
-                        argument=str(community_id),
-                        user=user, exclude=not allow))
+                db.session.add(ActionUsers(
+                    action=communities_read_all.value,
+                    argument=str(community_id),
+                    user=user, exclude=not allow))
 
         def update_permission(self, allow, community_id=None):
             with db.session.begin_nested():
                 user = accounts.datastore.get_user(self.user_id)
                 # only add the access rights if the access control is enabled
-                if not app.extensions[
-                        'b2share-communities'].rest_access_control_disabled:
-                    db.session.add(ActionUsers(
-                        action=communities_update_all.value,
-                        argument=str(community_id),
-                        user=user, exclude=not allow))
+                db.session.add(ActionUsers(
+                    action=communities_update_all.value,
+                    argument=str(community_id),
+                    user=user, exclude=not allow))
 
         def delete_permission(self, allow, community_id=None):
             with db.session.begin_nested():
                 user = accounts.datastore.get_user(self.user_id)
                 # only add the access rights if the access control is enabled
-                if not app.extensions[
-                        'b2share-communities'].rest_access_control_disabled:
-                    db.session.add(ActionUsers(
-                        action=communities_delete_all.value,
-                        argument=str(community_id),
-                        user=user, exclude=not allow))
+                db.session.add(ActionUsers(
+                    action=communities_delete_all.value,
+                    argument=str(community_id),
+                    user=user, exclude=not allow))
 
     return UserPermissionsFactory
 

--- a/tests/b2share_unit_tests/communities/test_communities_rest.py
+++ b/tests/b2share_unit_tests/communities/test_communities_rest.py
@@ -40,14 +40,6 @@ from b2share.modules.communities import Community
 from b2share.modules.communities.errors import CommunityDeletedError
 from b2share.modules.communities.models import Community as CommunityModel
 
-# Decorator running a community test with and without access control enabled
-community_with_and_without_access_control = pytest.mark.parametrize('app', [({
-    'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': True}
-}), ({
-    'config': {'B2SHARE_COMMUNITIES_REST_ACCESS_CONTROL_DISABLED': False}
-})],
-    indirect=['app'])
-
 
 # FIXME: Test is disabled for V2 as it is not used by the UI
 # @community_with_and_without_access_control
@@ -173,7 +165,6 @@ community_with_and_without_access_control = pytest.mark.parametrize('app', [({
 #         assert len(CommunityModel.query.all()) == 0
 
 
-@community_with_and_without_access_control
 def test_valid_get(app, login_user,
                    communities_permissions):
     """Test VALID community get request (GET .../communities/<id>)."""
@@ -216,7 +207,6 @@ def test_valid_get(app, login_user,
             subtest_self_link(response_data, headers, client)
 
 
-@community_with_and_without_access_control
 def test_invalid_get(app, login_user,
                      communities_permissions):
     """Test INVALID community get request (GET .../communities/<id>)."""
@@ -528,7 +518,6 @@ def test_invalid_get(app, login_user,
 
 
 # FIXME: Test is disabled for V2 as it is not used by the UI
-@community_with_and_without_access_control
 def test_action_on_deleted(app, login_user,
                            communities_permissions):
     """Test getting, deleting and updating a perviously deleted community."""

--- a/tests/b2share_unit_tests/schemas/test_schemas_api.py
+++ b/tests/b2share_unit_tests/schemas/test_schemas_api.py
@@ -50,9 +50,7 @@ from b2share_unit_tests.schemas.data import (
     backward_incompatible_block_schemas_json_schemas
 )
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
+
 def test_root_schema(app):
     """Test valid usage of the RootSchema API."""
     with app.app_context():
@@ -74,9 +72,6 @@ def test_root_schema(app):
             version += 1
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_root_schemas_backward_compatibility(app):
     """Test non backward compatible root schemas."""
     with app.app_context():
@@ -102,9 +97,6 @@ def test_root_schemas_backward_compatibility(app):
             RootSchema.get_root_schema(len(root_schemas_json_schemas) + 1)
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_root_schema_errors(app):
     """Test invalid usage of the RootSchema API."""
     with app.app_context():
@@ -170,9 +162,6 @@ def test_root_schema_errors(app):
             RootSchema.get_root_schema(42)
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_block_schemas(app):
     """Test valid usage of the BlockSchema API."""
     with app.app_context():
@@ -201,9 +190,6 @@ def test_block_schemas(app):
         assert retrieved_block_schema.name == new_name
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_block_schema_errors(app):
     """Test invalid usage of the BlockSchema API."""
     with app.app_context():
@@ -250,9 +236,6 @@ def test_block_schema_errors(app):
             db.session.commit()
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_block_schemas_versions(app):
     """Test valid usage of the BlockSchemaVersion API."""
     with app.app_context():
@@ -320,9 +303,6 @@ def test_block_schemas_versions(app):
             )
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_block_schemas_versions_backward_compatibility(app):
     """Test non backward compatible root schemas."""
     with app.app_context():
@@ -362,9 +342,6 @@ def test_block_schemas_versions_backward_compatibility(app):
             len(block_schemas_json_schemas[0])
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_block_schema_version_errors(app):
     """Test invalid usage of the BlockSchemaVersion API."""
     with app.app_context():
@@ -397,9 +374,6 @@ def test_block_schema_version_errors(app):
         assert len(block_schema.versions) == 0
 
 
-@pytest.mark.parametrize('app', [({'extensions':
-                                   [B2ShareCommunities, B2ShareSchemas]})],
-                         indirect=['app'])
 def test_community_schema(app, flask_http_responses):
     """Test valid usage of the CommunitySchema API."""
     with app.app_context():

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -35,12 +35,6 @@ from b2share.modules.schemas.cli import schemas as schemas_cmd
 from b2share_demo.cli import demo as demo_cmd
 
 
-@pytest.mark.parametrize('app', [({
-    'config': {'PREFERRED_URL_SCHEME': 'https'}
-}), ({
-    'config': {'PREFERRED_URL_SCHEME': 'http'}
-})],
-    indirect=['app'])
 def test_demo_cmd_load(app):
     """Test the `load` CLI command."""
     with app.app_context():


### PR DESCRIPTION
* Improves tests speed by changing the "app" fixture scope to
  "session". This avoids recreating the application for each
  test.

* Removes the possibility to disable access control for the
  communities REST API. Access control is now always enforced.

* Changes preferred URL scheme to "https" for all tests.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>