### PR TITLE
improvement to rabbitmq configuration

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -121,6 +121,8 @@ folder and run ``docker-compose``, e.g.:
     $ export B2SHARE_POSTGRESQL_DBNAME=...       # name of the postgresql database used by b2share
     $ export B2SHARE_POSTGRESQL_PASSWORD=...     # password used by b2share when accessing the postgresql database
     $ export B2SHARE_POSTGRESQL_USER=...         # username used by b2share when accessing the postgresql database (default=b2share)
+    $ export B2SHARE_RABBITMQ_USER=...           # username used by b2share when accessing RabbitMQ service
+    $ export B2SHARE_RABBITMQ_PASS=...           # password used by b2share when accessing RabbitMQ service
     $ export B2SHARE_DATADIR='<PATH>'            # path on the host which will be mounted and contain all b2share related data, including postgresql, elasticsearch, redis, rabbitmq, nginx and b2share itself.
 
     ## optional environment variables

--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "B2SHARE_CACHE_REDIS_HOST='redis'"
             - "B2SHARE_CACHE_REDIS_URL='redis://redis:6379/0'"
             - "B2SHARE_ACCOUNTS_SESSION_REDIS_URL='redis://redis:6379/1'"
-            - "B2SHARE_BROKER_URL='amqp://guest:guest@mq:5672//'"
+            - "B2SHARE_BROKER_URL='amqp://${B2SHARE_RABBITMQ_USER}:${B2SHARE_RABBITMQ_PASS}@mq:5672/'"
             - "B2SHARE_CELERY_RESULT_BACKEND='redis://redis:6379/2'"
             - "B2SHARE_SEARCH_ELASTIC_HOSTS='elasticsearch'"
         volumes:
@@ -68,13 +68,12 @@ services:
     mq:
         image: rabbitmq:3.6-management
         restart: "always"
+        environment:
+            - "RABBITMQ_DEFAULT_USER=${B2SHARE_RABBITMQ_USER}"
+            - "RABBITMQ_DEFAULT_PASS=${B2SHARE_RABBITMQ_PASS}"
         ports:
             - "15672"
             - "5672"
         read_only: true
         volumes:
             - "${B2SHARE_DATADIR}/rabbitmq-data:/var/lib/rabbitmq"
-        entrypoint:
-            - "rabbitmq-server"
-            - "--hostname"
-            - "b2share-redis"


### PR DESCRIPTION
The entrypoints prevent a script dockerize-entrypoint.sh from Dockerhub / rabbitmq to run, this is necessarily to prevent (new) default rabbitmq behaviour to only allow connections for guest user from localhost. Moreover, added settings so administrators can set different values for default username and password than guest / guest which is a security improvement.