### PR TITLE
Small fix in docker-compose.yml for bare-metal/dev installs

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -8,7 +8,7 @@
 #         - MYSQL_DATABASE=b2share_evo
 
 elasticsearch:
-    image: elasticsearch
+    build: ../dockerize/elasticsearch
     ports:
         - "9200:9200"
         - "9300:9300"


### PR DESCRIPTION
So you can run docker-compose from devenv which starts the services but not b2share itself to faciliate baremetal usage.