### PR TITLE
doc: fix the file upload curl command

### DIFF
--- a/webui/src/docs/rest-api.jsx
+++ b/webui/src/docs/rest-api.jsx
@@ -465,7 +465,7 @@ module.exports = function() {
             <li><p>Returns: informations about the newly uploaded file</p></li>
         </ul>
         <Example>
-            curl -X PUT -H 'Accept:application/json' -H 'Content-Type:application/octet-stream' -d @TestFileToBeUploaded.txt https://$HOSTNAME/api/files/$FILE_BUCKET_ID/TestFileToBeUploaded.txt?access_token=$ACCESS_TOKEN
+            curl -X PUT -H 'Accept:application/json' -H 'Content-Type:application/octet-stream' --data-binary @TestFileToBeUploaded.txt https://$HOSTNAME/api/files/$FILE_BUCKET_ID/TestFileToBeUploaded.txt?access_token=$ACCESS_TOKEN
         </Example>
 
         <h3 id="delete-file">Delete file from draft record</h3>


### PR DESCRIPTION
* Fixes a curl command in the documentation. This command was not
  using the right option to upload files. (addresses #1515)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>