### PR TITLE
ui: fix embargoed record stats

### DIFF
--- a/webui/src/components/editfiles.jsx
+++ b/webui/src/components/editfiles.jsx
@@ -525,7 +525,7 @@ export const FileRecordRow = React.createClass({
         let file = this.props.file;
         file = file.toJS ? file.toJS() : file;
 
-        if (! this.props.hideFileDownloads) {
+        if (! this.props.hideFileDownloads && file.bucket) {
             serverCache.getFileStatistics(file.bucket, (fileDownloads) => {
                 const downloads = _.chain(fileDownloads.buckets)
                   .keyBy('key').mapValues('value').value();


### PR DESCRIPTION
* FIX error in stats query occurring in a record page which has
  an embargo date.

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>