### PR TITLE
Remove direct requirement of celery, update celery config

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -258,7 +258,7 @@ CELERY_RESULT_BACKEND = "redis://localhost:6379/1"
 #: Accepted content types for Celery.
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 #: Beat schedule
-CELERYBEAT_SCHEDULE = {
+CELERY_BEAT_SCHEDULE = {
     'embargo-updater': {
         'task': 'b2share.modules.records.tasks.update_expired_embargoes',
         'schedule': crontab(minute=2, hour=0),

--- a/setup.py
+++ b/setup.py
@@ -31,16 +31,17 @@ from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 install_requires = [
-    'Flask-Login<0.4,>=0.3.2',
-    'celery>=3.1.24',  # TODO Unpin this once compatible with Celery 4.0
     'elasticsearch<3.0.0,>=2.0.0',
     'elasticsearch-dsl<3.0.0,>=2.0.0',
     'datacite>=0.3.0',
     'dcxml>=0.1.0',
+    'doschema>=1.0.0a1',
     'dojson>=1.2.1',
+    'easywebdav>=1.2.0',
+    'Flask-Login<0.4,>=0.3.2',
     'httplib2>=0.9.2',
     'invenio-access>=1.0.0a11,<1.1.0',
-    'invenio-accounts>=1.0.0b5,<1.1.0',
+    'invenio-accounts>=1.0.0b9,<1.1.0',
     'invenio-accounts-rest>=1.0.0a4,<1.1.0',
     'invenio-base>=1.0.0a14,<1.1.0',
     'invenio-celery>=1.0.0b1,<1.1.0',
@@ -61,11 +62,9 @@ install_requires = [
     'invenio-rest[cors]>=1.0.0a10,<1.1.0',
     'invenio-search>=1.0.0a10,<1.1.0',
     'invenio-stats>=1.0.0a7',
-    'jsonresolver[jsonschema]>=0.2.1',
     'invenio-logging>=1.0.0a3',
     'invenio-indexer>=1.0.0a9',
-    'easywebdav>=1.2.0',
-    'doschema>=1.0.0a1',
+    'jsonresolver[jsonschema]>=0.2.1',
 ]
 
 if sys.version_info < (3, 4):


### PR DESCRIPTION
Celery is still required by some invenio package.

Fixes:
````
UserWarning: Celery v4 installed, but detected Celery v3 configuration CELERYBEAT_SCHEDULE (use CELERY_BEAT_SCHEDULE instead).
````
