### PR TITLE
WIP ui: dropdown versions menu on deleted records

### DIFF
--- a/b2share/modules/records/views.py
+++ b/b2share/modules/records/views.py
@@ -439,6 +439,7 @@ class RecordsVersionsResource(ContentNegotiatedMethodView):
                                _external=True),
                 'created': rec_meta.created,
                 'updated': rec_meta.updated,
+                'deleted': rec_pid.status.value == 'D'
             })
         return {'versions': records}
 

--- a/webui/src/components/record.jsx
+++ b/webui/src/components/record.jsx
@@ -17,16 +17,11 @@ const PT = React.PropTypes;
 
 export const RecordRoute = React.createClass({
 
-    getVersions(versions){
-        this.versions = versions.versions;
-    },
-
     render() {
         const { id } = this.props.params;
         const record = serverCache.getRecord(id);
-        serverCache.getVersions(id, this.getVersions);
         if (record instanceof Error) {
-            return <Err err={record} id={id} versions={this.versions} />;
+            return <Err err={record} id={id} versions={record.versions} />;
         }
         if (!record) {
             return <Wait/>;

--- a/webui/src/components/versions.jsx
+++ b/webui/src/components/versions.jsx
@@ -73,6 +73,9 @@ const PublishedVersions = React.createClass({
         const VerItemRenderer = ({item}) => {
             const text = item.version == versions.length ? "Latest Version" : ("Version" + item.version);
             const creation = moment(item.created).format('ll');
+            if(item.deleted){
+                return (<span><strike>{text} - {creation}</strike></span>);
+            }
             return (<span>{text} - {creation}</span>);
         };
         const handleVersionChange = (v) => {

--- a/webui/src/components/versions.jsx
+++ b/webui/src/components/versions.jsx
@@ -66,13 +66,12 @@ const PublishedVersions = React.createClass({
 
     render() {
         let {recordID, versions, style} = this.props;
-        const beQuiet = recordID == versions[0].id;
-        const versionClass = beQuiet ? "" : "alert alert-warning";
-
+        const beQuiet = serverCache.checkLastActiveVersion(recordID, versions);
         const thisVersion = versions.find(v => recordID == v.id);
+
+        const versionClass = thisVersion.deleted || beQuiet ? "" : "alert alert-warning";
         const VerItemRenderer = ({item}) => {
-            const index = item.index + 1;
-            const text = index == versions.length ? "Latest Version" : ("Version" + index);
+            const text = item.version == versions.length ? "Latest Version" : ("Version" + item.version);
             const creation = moment(item.created).format('ll');
             return (<span>{text} - {creation}</span>);
         };
@@ -84,7 +83,7 @@ const PublishedVersions = React.createClass({
         return (
             <div className={versionClass} style={style}>
                 <div className="btn" style={{display: 'inline-block', color:'black', border: '0px solid #eee'}}>
-                    { beQuiet ? "" : "This record has newer versions. " }
+                    { thisVersion.deleted ? "" : beQuiet ? "" : "This record has newer versions. " }
                 </div>
 
                 <div style={{display: 'inline-block', verticalAlign: 'middle', marginBottom: '1px', padding: '0px', width: '17em'}}>

--- a/webui/src/components/waiting.jsx
+++ b/webui/src/components/waiting.jsx
@@ -1,4 +1,5 @@
 import React from 'react/lib/ReactWithAddons';
+import { Versions } from './versions.jsx';
 
 
 export const Wait = React.createClass({
@@ -17,10 +18,18 @@ export const Err = React.createClass({
         if (error.data && error.data.message) {
             msg = error.data.message;
         }
+        const showVersions = Boolean(this.props.versions);
         return (
             <div className={"alert alert-danger"}>
-                <h3>Error <span>{error.code}</span></h3>
-                <span>{msg}</span>
+                <div class="row">
+                    <div class="col-md-6">
+                        <h3>Error <span>{error.code}</span></h3>
+                        { showVersions ? <Versions recordID={this.props.id} versions={this.props.versions}/> : null }
+                    </div>
+                    <div class="col-md-6">
+                        <span>{msg}</span>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/webui/src/data/server.js
+++ b/webui/src/data/server.js
@@ -22,6 +22,7 @@ const apiUrls = {
 
     records()                         { return `${urlRoot}/api/records/` },
     recordsVersion(versionOf)         { return `${urlRoot}/api/records/?version_of=${versionOf}` },
+    versions(id)                      { return `${urlRoot}/api/records/${id}/versions` },
     record(id)                        { return `${urlRoot}/api/records/${id}` },
     draft(id)                         { return `${urlRoot}/api/records/${id}/draft` },
     fileBucket(bucket, key)           { return `${urlRoot}/api/files/${bucket}/${key}` },
@@ -530,6 +531,15 @@ class ServerCache {
         return file;
     }
 
+    getVersions(recordID, callback){
+        ajaxGet({
+            url: apiUrls.versions(recordID),
+            successFn: (versions) => {
+                callback(versions);
+            },
+        });
+    }
+
     // info and user can only be set once during a UI view; they will both be
     // refreshed when the page reloads (including when following hrefs)
     // user can be: null (uninitialized), {} (anonymous user), or {name,...}
@@ -873,6 +883,18 @@ class ServerCache {
                 notifications.danger("An error occured while trying to the role");
             },
         });
+    }
+
+    checkLastActiveVersion(recordID, versions){
+        if(versions){
+            for(var v=0; v<versions.length; v++){
+                var version = versions[v];
+                if(!version.deleted){
+                    return recordID == version.id;
+                }
+            }
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
* ADD the dropdown versions menu on the deleted record pages
  so that you can navigate.

* FIX show the `Create New Version` button only on the last
  non deleted version.
  (Closes https://github.com/EUDAT-B2SHARE/b2share/issues/1614)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>