### PR TITLE
check that all declared presentation items in schemas exist

### DIFF
--- a/webui/src/components/schema.jsx
+++ b/webui/src/components/schema.jsx
@@ -15,8 +15,10 @@ export function getSchemaOrderedMajorAndMinorFields(schema) {
     const presentation = schema.getIn(['b2share', 'presentation']);
     const properties = schema.get('properties');
 
-    const majorIDs = presentation ? presentation.get('major') : null;
-    const minorIDs = presentation ?  presentation.get('minor') : null;
+    const majorIDs = presentation && presentation.get('major') ?
+        presentation.get('major').filter(id => properties.get(id)) : null;
+    const minorIDs = presentation && presentation.get('minor') ?
+        presentation.get('minor').filter(id => properties.get(id)) : null;
 
     let minors = OrderedMap(minorIDs ? minorIDs.map(id => [id, properties.get(id)]) : []);
     let majors = OrderedMap(majorIDs ? majorIDs.map(id => [id, properties.get(id)]) : []);


### PR DESCRIPTION
The items in a community schema are displayed in the order defined by the 'presentation' declaration. But if the 'presentation' declares an item which is not actually available in the schema, the UI crashes. This PR checks that all items are present in the schema.

fixes #1619