### PR TITLE
WIP serializer: add external_pids if visible

### DIFF
--- a/b2share/modules/deposit/api.py
+++ b/b2share/modules/deposit/api.py
@@ -542,6 +542,18 @@ def copy_data_from_previous(previous_record):
     return copied_data
 
 
+def generate_external_pids(record):
+    """Generate the list of external files of a record sorted by key."""
+    external_pids = []
+    current_file_keys = [f for f in record.files if
+                         f.obj.file.storage_class == 'B']
+    current_file_keys.sort(key=lambda f: f.obj.key)
+    for f in current_file_keys:
+        external_pids.append({'key': f.obj.key,
+                              'ePIC_PID': f.obj.file.uri})
+    return external_pids
+
+
 copy_data_from_previous.extra_removed_fields = [
     'publication_state', 'publication_date', '$schema'
 ]

--- a/b2share/modules/deposit/api.py
+++ b/b2share/modules/deposit/api.py
@@ -50,6 +50,7 @@ from invenio_pidrelations.contrib.versioning import PIDVersioning
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_pidstore.resolver import Resolver
 from invenio_pidstore.errors import PIDDoesNotExistError
+from invenio_rest.errors import FieldError
 
 
 from .errors import (InvalidDepositError,
@@ -127,10 +128,9 @@ class Deposit(InvenioDeposit):
         # illusion that this field actually exist.
         # TODO: Note that the 'external_pids' field should in the end
         # be part of the root schema.
-        if 'external_pids' in data['_deposit']:
-            data['external_pids'] = copy.deepcopy(
-                data['_deposit']['external_pids']
-            )
+        external_pids = generate_external_pids(self)
+        if external_pids:
+            data['external_pids'] = external_pids
         data = apply_patch(data, patch)
 
         # if the 'external_pids' field was not modified we can discard it.
@@ -255,7 +255,6 @@ class Deposit(InvenioDeposit):
 
         if 'external_pids' in data:
             create_b2safe_file(data['external_pids'], bucket)
-            data['_deposit']['external_pids'] = data['external_pids']
             del data['external_pids']
 
         deposit = super(Deposit, cls).create(data, id_=id_)
@@ -330,10 +329,9 @@ class Deposit(InvenioDeposit):
                 elif object_version.file.uri != \
                         key_to_pid[object_version.key]:
                     db.session.query(FileInstance).\
-                        filter(FileInstance.id==object_version.file_id).\
+                        filter(FileInstance.id == object_version.file_id).\
                         update({"uri": key_to_pid[object_version.key]})
             create_b2safe_file(self['external_pids'], bucket)
-            self['_deposit']['external_pids'] = self['external_pids']
             del self['external_pids']
 
         if self.model is None or self.model.json is None:
@@ -367,6 +365,9 @@ class Deposit(InvenioDeposit):
                 previous_version_uuid = str(RecordUUIDProvider.get(
                     previous_version_pid.pid_value
                 ).pid.object_uuid)
+            external_pids = generate_external_pids(self)
+            if external_pids:
+                self['_deposit']['external_pids'] = external_pids
 
             super(Deposit, self).publish()  # publish() already calls commit()
             # Register parent PID if necessary and update redirect
@@ -405,7 +406,8 @@ class Deposit(InvenioDeposit):
         record_pid = RecordUUIDProvider.get(pid_value).pid
         version_master = PIDVersioning(child=record_pid)
         # every deposit has a parent version after the 2.1.0 upgrade
-        # except deleted ones. We check the parent version in case of a delete revert.
+        # except deleted ones. We check the parent version in case of a delete
+        # revert.
         assert version_master is not None, 'Unexpected deposit without versioning.'
         # if the record is unpublished hard delete it
         if record_pid.status == PIDStatus.RESERVED:
@@ -475,12 +477,16 @@ def create_b2safe_file(external_pids, bucket):
     keys_list = [e['key'] for e in external_pids]
     keys_set = set(keys_list)
     if len(keys_list) != len(keys_set):
-        raise InvalidDepositError(
-            'Field external_pids contains duplicate keys.')
+        raise InvalidDepositError([FieldError('external_pids',
+            'Field external_pids contains duplicate keys.')])
     for external_pid in external_pids:
-        if not external_pid['ePIC_PID'].startswith("http://hdl.handle.net/"):
-            external_pid['ePIC_PID'] = "http://hdl.handle.net/" + \
+        if not external_pid['ePIC_PID'].startswith('http://hdl.handle.net/'):
+            external_pid['ePIC_PID'] = 'http://hdl.handle.net/' + \
                 external_pid['ePIC_PID']
+        if external_pid['key'].startswith('/'):
+            raise InvalidDepositError(
+                [FieldError('external_pids',
+                            'File key cannot start with a "/".')])
         try:
             # Create the file instance if it does not already exist
             file_instance = FileInstance.get_by_uri(external_pid['ePIC_PID'])
@@ -496,7 +502,8 @@ def create_b2safe_file(external_pids, bucket):
                 ObjectVersion.create(bucket, external_pid['key'],
                                      file_instance.id)
         except IntegrityError as e:
-            raise InvalidDepositError('File URI already exists.')
+            raise InvalidDepositError(
+                [FieldError('external_pids', 'File URI already exists.')])
 
 
 def find_version_master_and_previous_record(version_of):

--- a/b2share/modules/deposit/fetchers.py
+++ b/b2share/modules/deposit/fetchers.py
@@ -28,12 +28,15 @@ from collections import namedtuple
 from .providers import DepositUUIDProvider
 
 
-FetchedPID = namedtuple('FetchedPID', ['provider', 'pid_type', 'pid_value'])
+FetchedPID = namedtuple('FetchedPID', ['provider', 'object_uuid',
+                                       'pid_type', 'pid_value'])
+
 
 def b2share_deposit_uuid_fetcher(record_uuid, data):
     """Fetch a deposit's identifiers."""
     return FetchedPID(
         provider=DepositUUIDProvider,
+        object_uuid=record_uuid,
         pid_type=DepositUUIDProvider.pid_type,
         pid_value=str(data['_deposit']['id']),
     )

--- a/b2share/modules/records/fetchers.py
+++ b/b2share/modules/records/fetchers.py
@@ -27,25 +27,29 @@ from collections import namedtuple
 
 from .providers import RecordUUIDProvider
 
-FetchedPID = namedtuple('FetchedPID', ['provider', 'pid_type', 'pid_value'])
-
-from invenio_records_rest.views import Blueprint
+FetchedPID = namedtuple('FetchedPID', ['provider', 'object_uuid',
+                                       'pid_type', 'pid_value'])
 
 
 def b2share_record_uuid_fetcher(record_uuid, data):
     """Fetch a record's identifiers."""
     return FetchedPID(
         provider=RecordUUIDProvider,
+        object_uuid=record_uuid,
         pid_type=RecordUUIDProvider.pid_type,
         pid_value=str(next(pid['value'] for pid in data['_pid']
                            if pid['type'] == RecordUUIDProvider.pid_type)),
     )
 
+
 def b2share_parent_pid_fetcher(record_uuid, data):
     """Fetch record's parent version persistent identifier."""
     return FetchedPID(
         provider=RecordUUIDProvider,
+        # The record_uuid is not relevant for the parent pids
+        # but it is added in the signature for consistency.
+        object_uuid=None,
         pid_type=RecordUUIDProvider.pid_type,
         pid_value=next(pid['value'] for pid in data['_pid']
-                        if pid['type'] == RecordUUIDProvider.parent_pid_type)
+                       if pid['type'] == RecordUUIDProvider.parent_pid_type)
     )

--- a/b2share/modules/records/indexer.py
+++ b/b2share/modules/records/indexer.py
@@ -51,7 +51,7 @@ def indexer_receiver(sender, json=None, record=None, index=None,
     if 'external_pids' in json['_deposit']:
         # Keep the 'external_pids' if the record is a draft (deposit) or
         # if the files are public.
-        if (is_deposit(record.model) or allow_public_file_metadata(json)):
+        if (not is_deposit(record.model) and allow_public_file_metadata(json)):
             json['external_pids'] = json['_deposit']['external_pids']
         del json['_deposit']['external_pids']
     if not index.startswith('records'):

--- a/b2share/modules/records/serializers/schemas/json.py
+++ b/b2share/modules/records/serializers/schemas/json.py
@@ -23,8 +23,13 @@
 
 """B2Share Records JSON schemas used for serialization."""
 
+from flask import g
 from marshmallow import Schema, fields, pre_dump
 from b2share.modules.access.policies import allow_public_file_metadata
+from b2share.modules.deposit.api import generate_external_pids
+from b2share.modules.files.permissions import files_permission_factory
+from b2share.modules.records.utils import is_deposit
+from invenio_records_files.models import Bucket
 
 
 DOI_URL_PREFIX = 'http://doi.org/'
@@ -43,19 +48,41 @@ class DraftSchemaJSONV1(Schema):
     @pre_dump
     def filter_internal(self, data):
         """Remove internal fields from the record metadata."""
+        external_pids = []
+        bucket = None
+        record = None
+        if hasattr(g, 'record'):
+            record = g.record
+            if record.files:
+                bucket = Bucket.query.filter_by(
+                    id=str(record.files.bucket)).first()
+            if is_deposit(record.model):
+                external_pids = generate_external_pids(record)
+            # if it is a published record don't generate external pids
+            # as they are immutable and stored in _deposit
+            else:
+                external_pids = record.model.json[
+                    '_deposit'].get('external_pids')
+
         if '_deposit' in data['metadata']:
-            if 'external_pids' in data['metadata']['_deposit']:
-                data['metadata']['external_pids'] = \
-                    data['metadata']['_deposit']['external_pids']
             data['metadata']['owners'] = data['metadata']['_deposit']['owners']
+            # Add the external_pids only if the
+            # user is allowed to read the bucket
+            if external_pids and record and bucket:
+                if (files_permission_factory(bucket, 'bucket-read').can() or
+                        allow_public_file_metadata(record)):
+                    data['metadata']['external_pids'] = external_pids
             del data['metadata']['_deposit']
         if '_files' in data['metadata']:
-            if allow_public_file_metadata(data['metadata']):
+            # Also add the files field only if the user is allowed
+            if (bucket and files_permission_factory(
+                bucket, 'bucket-read').can()) or \
+                    allow_public_file_metadata(data['metadata']):
                 data['files'] = data['metadata']['_files']
                 for _file in data['files']:
                     if 'external_pids' in data['metadata'] and \
                             any(d['key'] == _file['key']
-                                for d in data['metadata']['external_pids']):
+                                for d in external_pids):
                         _file['b2safe'] = True
             del data['metadata']['_files']
         if '_pid' in data['metadata']:

--- a/tests/b2share_functional_tests/test_submission.py
+++ b/tests/b2share_functional_tests/test_submission.py
@@ -254,7 +254,7 @@ def subtest_deposit(app, test_communities, allowed_user, other_user,
 
             # test that published record's files match too
             test_files(client, record_get_data['links']['files'],
-                        uploaded_files)
+                       uploaded_files)
 
             created_records[record_get_data['id']] = record_get_data
 

--- a/tests/b2share_unit_tests/deposit/test_deposit_api.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_api.py
@@ -224,14 +224,6 @@ def test_change_deposit_schema_fails(app, draft_deposits):
             deposit.commit()
 
 
-def test_create_deposit_with_external_pids(app, deposit_with_external_pids):
-    expected_files = \
-        deposit_with_external_pids.data['_deposit']['external_pids']
-    with app.app_context():
-        assert_external_files(deposit_with_external_pids.get_deposit(),
-                              expected_files)
-
-
 def test_create_deposit_with_external_pids_errors(
         app, records_data_with_external_pids):
     """Test errors when a deposit is created with invalid external files."""

--- a/tests/b2share_unit_tests/deposit/test_deposit_rest.py
+++ b/tests/b2share_unit_tests/deposit/test_deposit_rest.py
@@ -138,7 +138,6 @@ def test_deposit_invalid_patch_external_pids(app, draft_deposits,
         with app.test_client() as client:
             user = test_users['deposits_creator']
             login_user(user, client)
-
             # Test replace out of external pids array's bounds
             draft_patch_res = client.patch(
                 url_for('b2share_deposit_rest.b2dep_item',
@@ -162,6 +161,7 @@ def test_deposit_invalid_patch_external_pids(app, draft_deposits,
 
 
 def test_deposit_patch_external_pids(app, deposit_with_external_pids,
+                                     records_data_with_external_pids,
                                      test_users, login_user):
     newfile = "http://hdl.handle.net/11304/730e10a7-46d5-48fc-b192-7d716adb686a"
     patch = json.dumps([{
@@ -174,7 +174,7 @@ def test_deposit_patch_external_pids(app, deposit_with_external_pids,
     with app.app_context():
         # Build the expected list of files
         expected_files = deepcopy(
-            deposit_with_external_pids.data['_deposit']['external_pids']
+            records_data_with_external_pids['external_pids']
         )
         expected_files[0]['ePIC_PID'] = newfile
 


### PR DESCRIPTION
* ADD permission checking when an individual record
  or deposit is retrieved to add the external_pids field.
  (addresses https://github.com/EUDAT-B2SHARE/b2share/issues/1636)
  (generation of external pids from record.files needs a unit test)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>