### PR TITLE
upgrade: remove useless tasks from 2.1.1 upgrade

### DIFF
--- a/b2share/modules/upgrade/upgrades/upgrade_2_1_0_to_2_1_1.py
+++ b/b2share/modules/upgrade/upgrades/upgrade_2_1_0_to_2_1_1.py
@@ -35,8 +35,5 @@ from .common import elasticsearch_index_destroy, elasticsearch_index_init, \
 
 migrate_2_1_0_to_2_1_1 = UpgradeRecipe('2.1.0', '2.1.1')
 
-
-for step in [fix_communities, elasticsearch_index_destroy,
-             elasticsearch_index_init, elasticsearch_index_reindex,
-             queues_declare]:
-    migrate_2_1_0_to_2_1_1.step()(step)
+# No need to execute anything for this upgrade. There are no change to the
+# Database schema and the external pids are added to new records.


### PR DESCRIPTION
* Removes all tasks from the upgrade recipe 2.1.0->2.1.1 as
  the database schema doesn't change and the external pids
  are only added to new records.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>