### PR TITLE
travis: pinning responses version to <=0.10.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ tests_require = [
     'pytest>=2.8.0',
     'Flask-Testing',
     'mock',
-    'responses>=0.5.1',
+    'responses>=0.5.1,<=0.10.6',
 ]
 
 extras_require = {


### PR DESCRIPTION
* pinning responses version to <=0.10.6
  since it causes a jsonschema.exceptions.RefResolutionError
  in test_schemas_api.py.

* responses > 0.10.11 might fix the issue

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@csc.fi>