### PR TITLE
Fix community API bug

### DIFF
--- a/b2share/modules/schemas/api.py
+++ b/b2share/modules/schemas/api.py
@@ -558,13 +558,13 @@ class CommunitySchema(object):
                     ).one()
                 else:
                     model = CommunitySchemaVersion.query.filter(
-                        CommunitySchemaVersion.community == community_id
+                        CommunitySchemaVersion.community == str(community_id)
                     ).order_by(
                         CommunitySchemaVersion.version.desc()
                     ).limit(1).one()
                 return cls(model)
         except NoResultFound as e:
-            raise CommunitySchemaDoesNotExistError(id) from e
+            raise CommunitySchemaDoesNotExistError(str(community_id)) from e
 
     @classmethod
     def create_version(cls, community_id, community_schema,


### PR DESCRIPTION
A community not having a community schema caused the community REST API to
throw an error. A community should have a community schema, but this
caused test_communities_rest.test_valid_get() to fail since no schema
is created in that test.