### PR TITLE
Record landing page UI improvements

### DIFF
--- a/webui/src/components/editfiles.jsx
+++ b/webui/src/components/editfiles.jsx
@@ -692,6 +692,11 @@ export const FileRecordRow = React.createClass({
         };
     },
 
+    copyIdentifier(id, msg='Item') {
+        copyToClipboard(id);
+        alert(msg + ' copied to clipboard!');
+    },
+
     render() {
         let file = this.props.file;
         file = file.toJS ? file.toJS() : file;
@@ -727,14 +732,14 @@ export const FileRecordRow = React.createClass({
                     }</div>
                     <div className="col-sm-2 buttons">
                             { this.props.b2noteWidget }
-                            {/* !file.checksum ? false :
-                            <button type="button" className="btn btn-default btn-xs" onClick={() => copyToClipboard(file.checksum)} title="Copy checksum to clipboard">
+                            { !file.checksum ? false :
+                            <button type="button" className="btn btn-default btn-xs" onClick={() => this.copyIdentifier(file.checksum, 'File checksum')} title="Copy checksum to clipboard">
                                 <i className="glyphicon glyphicon-asterisk"/>
                             </button> }
                             { !file.ePIC_PID ? false :
-                            <button type="button" className="btn btn-default btn-xs" onClick={() => copyToClipboard(file.ePIC_PID)} title="Copy PID to clipboard">
+                            <button type="button" className="btn btn-default btn-xs" onClick={() => this.copyIdentifier(file.ePIC_PID, 'File EPIC PID')} title="Copy PID to clipboard">
                                 <i className="glyphicon glyphicon-globe"/>
-                            </button>*/ }
+                            </button> }
                             { !this.props.remove ? false :
                             <button type="button" className="btn btn-default btn-xs remove" onClick={()=>this.setState({remove:true})} title="Delete">
                                 <i className="glyphicon glyphicon-remove"/>

--- a/webui/src/components/editfiles.jsx
+++ b/webui/src/components/editfiles.jsx
@@ -682,7 +682,7 @@ export const FileRecordRow = React.createClass({
     propTypes: {
         file: PT.object.isRequired,
         remove: PT.func,
-        b2noteWidget: PT.object,
+        b2noteWidget: PT.oneOfType([PT.object, PT.bool]),
     },
 
     getInitialState() {

--- a/webui/src/components/record.jsx
+++ b/webui/src/components/record.jsx
@@ -31,8 +31,8 @@ export const RecordRoute = React.createClass({
 
     render() {
         const record = this.getRecordOrDraft();
-        const b2noteUrl = serverCache.getInfo().get('b2note_url');
-        if (!record || !b2noteUrl) {
+        const b2noteUrl = serverCache.getInfo().get('b2note_url', '');
+        if (!record || b2noteUrl === null) {
             return <Wait/>;
         }
         if (record instanceof Error) {
@@ -508,7 +508,8 @@ const Record = React.createClass({
         const blockSchemas = this.props.blockSchemas;
         const record = this.props.record;
         const b2noteUrl = this.props.b2noteUrl;
-        if (!record || !rootSchema || !b2noteUrl) {
+
+        if (!record || !rootSchema) {
             return <Wait/>;
         }
 


### PR DESCRIPTION
Enables record landing page's file clipboard buttons and adds alert. 

Hides B2NOTE buttons if path not configured.

closes #1810 
closes #1789 
closes #1788
closes #1787 
