### PR TITLE
Fix OAuth2 special char issue and update B2ACCESS test server address

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -205,7 +205,7 @@ B2ACCESS_APP_CREDENTIALS = dict(
 
 B2ACCESS_BASE_URL = 'https://b2access.eudat.eu/'
 if os.environ.get("USE_STAGING_B2ACCESS"):
-    B2ACCESS_BASE_URL = 'https://unity.eudat-aai.fz-juelich.de/'
+    B2ACCESS_BASE_URL = 'https://b2access-integration.fz-juelich.de'
 
 OAUTHCLIENT_REMOTE_APPS = dict(
     b2access=make_b2access_remote_app(B2ACCESS_BASE_URL)

--- a/b2share/modules/oauthclient/b2access.py
+++ b/b2share/modules/oauthclient/b2access.py
@@ -113,6 +113,7 @@ class B2AccessOAuthRemoteApp(OAuthRemoteApp):
             # set the Authentication header
             headers={
                 'Authorization': 'Basic {}'.format(b2access_basic_auth),
+                'Content-Type': 'application/x-www-form-urlencoded',
             },
             data=to_bytes(body, self.encoding),
             method=self.access_token_method,

--- a/b2share/modules/oauthclient/b2access.py
+++ b/b2share/modules/oauthclient/b2access.py
@@ -25,7 +25,7 @@
 
 import base64
 
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote
 from flask import abort, current_app, redirect, request, \
     session, url_for
 from flask_oauthlib.client import OAuthException, OAuthRemoteApp, \
@@ -105,7 +105,7 @@ class B2AccessOAuthRemoteApp(OAuthRemoteApp):
         remote_args.update(self.access_token_params)
         # build the Basic HTTP Authentication code
         b2access_basic_auth = base64.encodestring(bytes('{0}:{1}'.format(
-            self.consumer_key, self.consumer_secret),
+            self.consumer_key, quote(self.consumer_secret)),
             'utf-8')).decode('ascii').replace('\n', '')
         body = client.prepare_request_body(**remote_args)
         resp, content = self.http_request(


### PR DESCRIPTION
B2SHARE's B2ACCESS OAuth2 implementation don't support %-sign in client secret. The problem is `b2access_basic_auth` variable, where client secret has not been encoded properly. Added `urllib.parse.quote` function to encode client secret.

Added `Content-Type` header for good practice. The header can also be found in [flask-oauthlib/client.py](https://github.com/lepture/flask-oauthlib/blob/master/flask_oauthlib/client.py#L666) line 666. B2SHARE implementation overrides these functionalities and thus the header is not automatically added.

B2ACCESS test server has been changed to integration B2ACCESS server due to removal of old test server. Changed server address to B2SHARE config.py file.

closes #1868 , closes #1867 