### PR TITLE
Update from B2HANDLE to pyhandle library

### DIFF
--- a/b2share/modules/handle/ext.py
+++ b/b2share/modules/handle/ext.py
@@ -21,7 +21,7 @@
 
 from __future__ import absolute_import, print_function
 
-from b2handle.handleclient import EUDATHandleClient
+from pyhandle.client.resthandleclient import RESTHandleClient
 from flask import current_app
 
 from .api import (create_handle, create_fake_handle, create_epic_handle,
@@ -47,7 +47,7 @@ class _B2ShareHandleState(object):
         if credentials:
             self.handle_prefix = credentials.get('prefix')
             assert self.handle_prefix
-            self.handle_client = EUDATHandleClient(**credentials)
+            self.handle_client = RESTHandleClient(**credentials)
 
 
     def create_handle(self, location, checksum=None, fixed=False,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 install_requires = [
-    'b2handle>=1.1.1,<2.0.0',
+    'pyhandle>=1.1.1,<=1.2.0',
     'elasticsearch<3.0.0,>=2.0.0',
     'elasticsearch-dsl<3.0.0,>=2.0.0',
     'datacite>=1.1.1',


### PR DESCRIPTION
Change B2HANDLE library to pyhandle library since B2HANDLE has been deprecated.
