### PR TITLE
Blur community description when it's too long

### DIFF
--- a/webui/app/css/app.css
+++ b/webui/app/css/app.css
@@ -800,6 +800,23 @@ a.navbar-brand {
 /*****************************************************************************/
 /* communities */
 
+.blur-overlay {
+  position: absolute;
+  top: -3px;
+  left: 0;
+  right: 0;
+  bottom: -10px;
+  background: linear-gradient(transparent 65%, rgba(255, 255, 255, 1) 95%, rgba(255, 255, 255, 1) 10%, rgba(255, 255, 255, 1) 100%);
+  pointer-events: none; /* Makes it non-interactive so users can still select the text underneath */
+  box-sizing: border-box; /* Ensure that padding and border are included in total width/height */
+}
+
+.community {
+  padding-bottom: 5px;
+  position: relative; /* Needed to position child elements like .blur-overlay relative to this container. */
+  overflow: hidden;   /* Any child content that's outside the boundaries of .community will be clipped (not displayed). */
+}
+
 .community-small {
   background-color: white;
   border: 1px solid #eee;


### PR DESCRIPTION
It will only execute if the text is over 150 characters long. For example:

![Screenshot from 2023-08-26 23-31-48](https://github.com/EUDAT-B2SHARE/b2share/assets/19774563/288e79b1-801e-45c8-b57e-c5fb7ea779bf)

@hjhsalo @JohannesLares 
