### PR TITLE
Fix the parsing of ePIC PIDs

### DIFF
--- a/b2share/modules/handle/api.py
+++ b/b2share/modules/handle/api.py
@@ -208,7 +208,7 @@ def create_epic_handle(location, checksum=None):
 
     # get the handle as returned by EPIC
     hdl = response['location']
-    pid = '/'.join(urlparse(hdl).path.split('/')[3:])
+    pid = '/'.join(urlparse(hdl).path.split('/')[-2:])
 
     CFG_HANDLE_SYSTEM_BASEURL = current_app.config.get(
         'CFG_HANDLE_SYSTEM_BASEURL')


### PR DESCRIPTION
If the variable hdl is, for example, `http://hdl.handle.net/21.T11975/b85684f9-5e24-4731-a6e2-94a8d277b838`, with the original code with `[3:]`, the output would be an empty string. With the updated code with `[-2:]`, the output would be:
`21.T11975/b85684f9-5e24-4731-a6e2-94a8d277b838`

@hjhsalo @JohannesLares 