### PR TITLE
Add production link to homepage

### DIFF
--- a/b2share/config.py
+++ b/b2share/config.py
@@ -426,6 +426,9 @@ SITE_FUNCTION = 'demo' # set to "production" on production instances
 # if the TRAINING_SITE_LINK parameter is not empty, a message will show up
 # on the front page redirecting the testers to this link
 TRAINING_SITE_LINK = ""
+# if the PRODUCTION_SITE_LINK parameter is not empty, a message will show up
+# on the front page redirecting the user to the production instance
+PRODUCTION_SITE_LINK = ""
 
 
 # Invenio Stats

--- a/b2share/modules/apiroot/views.py
+++ b/b2share/modules/apiroot/views.py
@@ -44,6 +44,7 @@ class ApiRoot(ContentNegotiatedMethodView):
             'version': __version__,
             'site_function': current_app.config.get('SITE_FUNCTION', ''),
             'training_site_link': current_app.config.get('TRAINING_SITE_LINK', ''),
+            'production_site_link': current_app.config.get('PRODUCTION_SITE_LINK', ''),
             'b2access_registration_link': b2access.get('registration_url'),
             # 'b2note_url': current_app.config.get('B2NOTE_URL'),
             'terms_of_use_link': current_app.config.get('TERMS_OF_USE_LINK'),

--- a/tests/b2share_unit_tests/apiroot/test_apiroot_rest.py
+++ b/tests/b2share_unit_tests/apiroot/test_apiroot_rest.py
@@ -43,4 +43,5 @@ def test_info_get(app):
             info = get_info()
             assert info['site_function'] == app.config.get("SITE_FUNCTION")
             assert info['training_site_link'] == app.config.get("TRAINING_SITE_LINK")
+            assert info['production_site_link'] == app.config.get("PRODCUTION_SITE_LINK")
             assert info['version'] == __version__

--- a/webui/src/components/home.jsx
+++ b/webui/src/components/home.jsx
@@ -13,6 +13,7 @@ export const HomeRoute = React.createClass({
         const site_function = info.get('site_function');
         const b2access = info.get('b2access_registration_link');
         const training_site = info.get('training_site_link');
+        const production_site = info.get('production_site_link');
         const divStyle = {
             color: 'red',
           };
@@ -34,6 +35,9 @@ export const HomeRoute = React.createClass({
                             <p >Use a production service provided by your institution or EUDAT for real research data.</p>
                             </div>
                             }
+                            { (site_function != "" && site_function != "production" && production_site != "") ?
+                                <p>Production instance link : <a href={production_site}>{production_site.split("//")[1].replace("/","")}</a></p>
+                                : false }
                             { training_site ?
                                 <p>Please use <a href={training_site}>{training_site}</a> for testing or training.</p>
                                 : false }

--- a/webui/src/data/server.js
+++ b/webui/src/data/server.js
@@ -286,6 +286,7 @@ class ServerCache {
                 version: "",
                 site_function: "",
                 training_site_link: "",
+                production_site_link: "",
                 b2access_registration_link: "",
                 b2note_url: "",
                 terms_of_use_link: "",


### PR DESCRIPTION
- Set the B2SHARE_PRODUCTION_SITE_LINK env variable to show the link to the production instance.