### PR TITLE
Upgrade psycopg version where found

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,4 +33,4 @@ invenio-rest[cors]<1.1.0,>=1.0.0a10
 invenio-search<1.1.0,>=1.0.0a10
 invenio-stats>=1.0.0a7
 jsonresolver[jsonschema]>=0.2.1
-psycopg2>=2.6.1
+psycopg2==2.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ ordereddict==1.1          # via invenio-query-parser
 passlib==1.7.1            # via flask-security, invenio-accounts
 pluggy==0.13.1             # via jsonresolver
 poyo==0.4.0               # via cookiecutter
-psycopg2==2.8.3
+psycopg2==2.9.5           # Upgraded from 2.8.3 due to having sufficient libpq for SCRAM authentication
 pyasn1==0.1.9             # via cryptography
 pycparser==2.17           # via cffi
 pyjwt==1.7.1              # via invenio-accounts, invenio_files_rest

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ extras_require = {
         'pymysql>=0.6.7',
     ],
     'postgresql': [
-        'psycopg2>=2.6.1',
+        'psycopg2==2.9.5',
     ],
     'docs': [
         "Sphinx>=1.3",


### PR DESCRIPTION
At minimum libpq 10 is needed for connecting to the database with scram encryption enabled for logins.